### PR TITLE
docs: agent & developer onboarding improvements (RPC discoverability, quickstarts, tx fix)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -505,6 +505,16 @@
   },
   "redirects": [
     {
+      "source": "/learn/getting-started",
+      "destination": "/learn",
+      "permanent": true
+    },
+    {
+      "source": "/evm/getting-started",
+      "destination": "/learn",
+      "permanent": true
+    },
+    {
       "source": "/evm/ai-tooling/mcp-server",
       "destination": "/ai/mcp-server",
       "permanent": true

--- a/evm/building-a-frontend.mdx
+++ b/evm/building-a-frontend.mdx
@@ -102,7 +102,7 @@ touch src/wagmi.ts
 
 ## Defining the ERC20 Contract Details
 
-<Info>Make sure to deploy your ERC20 token contract first and replace `TOKEN_CONTRACT_ADDRESS` in the constants file with your actual deployed contract address, and update the RPC URL in the Sei chain configuration. You can find a list of existing ERC20 contracts on Sei Mainnet here: [Sei Assets](https://seiscan.io/tokens)</Info>
+<Info>Make sure to deploy your ERC20 token contract first — for example with [Hardhat](/evm/evm-hardhat) or [Foundry](/evm/evm-foundry), or generate one with the [contract wizard](/evm/evm-wizard) (see also [deploy & verify](/evm/evm-parity/examples/deploy-verify)) — and replace `TOKEN_CONTRACT_ADDRESS` in the constants file with your actual deployed contract address, and update the RPC URL in the Sei chain configuration. You can find a list of existing ERC20 contracts on Sei Mainnet here: [Sei Assets](https://seiscan.io/tokens)</Info>
 
 Let's create a shared constants file for our project:
 
@@ -218,7 +218,7 @@ export const ERC20_ABI = [
   }
 ];
 
-// TODO: Replace with your deployed ERC20 token contract address
+// TODO: Deploy an ERC-20 (see /evm/evm-hardhat or /evm/evm-foundry) and paste its address here
 export const TOKEN_CONTRACT_ADDRESS = '0xYourTokenContractAddress';
 ```
 

--- a/evm/evm-parity/examples/ethers-quickstart.mdx
+++ b/evm/evm-parity/examples/ethers-quickstart.mdx
@@ -23,15 +23,28 @@ const provider = new ethers.JsonRpcProvider('https://evm-rpc.sei-apis.com');
 
 ## Reading Chain Data
 
+This is the first milestone — it needs no private key.
+
 ```ts
-const blockNumber = await provider.getBlockNumber();
+const blockNumber = await provider.getBlockNumber(); // number
+console.log('Block number:', blockNumber);
 
-const block = await provider.getBlock('latest');
+const balance = await provider.getBalance('0xYourAddress'); // bigint, wei
+console.log('Balance (SEI):', ethers.formatEther(balance));
 
-const balance = await provider.getBalance('0xYourAddress');
-
-const nonce = await provider.getTransactionCount('0xYourAddress');
+const nonce = await provider.getTransactionCount('0xYourAddress'); // number
+console.log('Nonce:', nonce);
 ```
+
+**You're done when you see:**
+
+```text
+Block number: 148203117
+Balance (SEI): 12.5
+Nonce: 7
+```
+
+The exact numbers are illustrative — your block number and balance will differ. `getBlockNumber()` and `getTransactionCount()` return a `number`, while `getBalance()` returns a `bigint` in wei (format it with `ethers.formatEther()`).
 
 ## Browser Provider
 
@@ -52,6 +65,8 @@ const wallet = new ethers.Wallet('0xYourPrivateKey', provider);
 ```
 
 ## Sending a Transaction
+
+Next step — this requires a funded account; get testnet SEI from the [faucet](/learn/faucet).
 
 ```ts
 const tx = await wallet.sendTransaction({
@@ -103,6 +118,34 @@ contract.on('Transfer', (from, to, value) => {
 // Stop listening
 contract.off('Transfer');
 ```
+
+## Using Python (web3.py)
+
+Sei is fully EVM-compatible, so any standard Ethereum client works — including Python's [web3.py](https://web3py.readthedocs.io).
+
+```bash
+pip install web3
+```
+
+```python
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("https://evm-rpc.sei-apis.com"))
+
+print("Connected:", w3.is_connected())
+print("Latest block:", w3.eth.block_number)
+print("Chain ID:", w3.eth.chain_id)  # 1329
+```
+
+**You're done when you see:**
+
+```text
+Connected: True
+Latest block: 148203117
+Chain ID: 1329
+```
+
+The block number is illustrative; the chain ID is always `1329` on mainnet.
 
 ## Next Steps
 

--- a/evm/evm-parity/examples/viem-quickstart.mdx
+++ b/evm/evm-parity/examples/viem-quickstart.mdx
@@ -38,15 +38,30 @@ const client = createPublicClient({
 
 ## Reading Chain Data
 
+This is the first milestone — it needs no private key.
+
 ```ts
-const blockNumber = await client.getBlockNumber();
+import { formatEther } from 'viem';
 
-const block = await client.getBlock({ blockTag: 'latest' });
+const blockNumber = await client.getBlockNumber(); // bigint
+console.log('Block number:', blockNumber);
 
-const balance = await client.getBalance({ address: '0xYourAddress' });
+const balance = await client.getBalance({ address: '0xYourAddress' }); // bigint, wei
+console.log('Balance (SEI):', formatEther(balance));
 
-const nonce = await client.getTransactionCount({ address: '0xYourAddress' });
+const nonce = await client.getTransactionCount({ address: '0xYourAddress' }); // number
+console.log('Nonce:', nonce);
 ```
+
+**You're done when you see:**
+
+```text
+Block number: 148203117n
+Balance (SEI): 12.5
+Nonce: 7
+```
+
+The exact numbers are illustrative — your block number and balance will differ. Note the trailing `n`: `getBlockNumber()` and `getBalance()` return `bigint`, while `getTransactionCount()` returns a `number`.
 
 ## Wallet Client
 
@@ -69,6 +84,8 @@ const walletClient = createWalletClient({
 For browser use, replace `http()` with `custom(window.ethereum)` and call `walletClient.getAddresses()` to get the connected account.
 
 ## Sending a Transaction
+
+Next step — this requires a funded account; get testnet SEI from the [faucet](/learn/faucet).
 
 ```ts
 import { parseEther } from 'viem';
@@ -136,6 +153,34 @@ const gas = await client.estimateGas({
   data: '0xCalldata',
 });
 ```
+
+## Using Python (web3.py)
+
+Sei is fully EVM-compatible, so any standard Ethereum client works — including Python's [web3.py](https://web3py.readthedocs.io).
+
+```bash
+pip install web3
+```
+
+```python
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("https://evm-rpc.sei-apis.com"))
+
+print("Connected:", w3.is_connected())
+print("Latest block:", w3.eth.block_number)
+print("Chain ID:", w3.eth.chain_id)  # 1329
+```
+
+**You're done when you see:**
+
+```text
+Connected: True
+Latest block: 148203117
+Chain ID: 1329
+```
+
+The block number is illustrative; the chain ID is always `1329` on mainnet.
 
 ## Next Steps
 

--- a/evm/index.mdx
+++ b/evm/index.mdx
@@ -74,11 +74,26 @@ keywords: ["sei evm", "ethereum virtual machine", "web3 development", "blockchai
 
 ## RPC Endpoints
 
-Choose from official Sei Foundation endpoints or community-maintained alternatives. All endpoints support standard EVM JSON-RPC methods. Public endpoints have rate limits—for production apps, consider using a dedicated RPC provider or running your own node.
+Choose from official Sei Foundation endpoints or community-maintained alternatives. All endpoints support standard EVM JSON-RPC methods. Public endpoints have rate limits — for production apps, use a [dedicated RPC provider](/learn/rpc-providers) or [run your own node](/node).
 
-<iframe
-  src="https://sei-widgets.vercel.app/rpc-selector"
-  style={{ width: "100%", minHeight: "520px", border: "0" }}
-  loading="lazy"
-  title="Sei RPC selector"
-/>
+<Tabs>
+  <Tab title="Mainnet (pacific-1)">
+    | Endpoint | Provider | Type | Rate limit | Notes |
+    | --- | --- | --- | --- | --- |
+    | `https://evm-rpc.sei-apis.com` | Sei Foundation | <span style={{ backgroundColor: 'rgba(34,197,94,0.15)', color: '#16a34a', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 600 }}>public</span> | 10 req/s | Recommended for development |
+    | `https://evm-rpc-sei.stingray.plus` | Staketab | <span style={{ backgroundColor: 'rgba(34,197,94,0.15)', color: '#16a34a', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 600 }}>public</span> | — | Community maintained |
+    | `https://sei-evm-rpc.publicnode.com` | PublicNode | <span style={{ backgroundColor: 'rgba(34,197,94,0.15)', color: '#16a34a', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 600 }}>public</span> | 5 req/s | Community maintained |
+    | `https://seievm-rpc.polkachu.com` | Polkachu | <span style={{ backgroundColor: 'rgba(34,197,94,0.15)', color: '#16a34a', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 600 }}>public</span> | — | Community maintained |
+    | `https://jsonrpc.lavenderfive.com:443/sei` | LavenderFive | <span style={{ backgroundColor: 'rgba(34,197,94,0.15)', color: '#16a34a', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 600 }}>public</span> | — | Community maintained |
+  </Tab>
+  <Tab title="Testnet (atlantic-2)">
+    | Endpoint | Provider | Type | Rate limit | Notes |
+    | --- | --- | --- | --- | --- |
+    | `https://evm-rpc-testnet.sei-apis.com` | Sei Foundation | <span style={{ backgroundColor: 'rgba(34,197,94,0.15)', color: '#16a34a', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 600 }}>public</span> | 20 req/s | Recommended for testing |
+    | `https://evm-rpc-testnet-sei.stingray.plus` | Staketab | <span style={{ backgroundColor: 'rgba(34,197,94,0.15)', color: '#16a34a', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 600 }}>public</span> | — | Community maintained |
+    | `https://seievm-testnet-rpc.polkachu.com` | Polkachu | <span style={{ backgroundColor: 'rgba(34,197,94,0.15)', color: '#16a34a', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 600 }}>public</span> | — | Community maintained |
+    | `https://sei-testnet.drpc.org` | dRPC | <span style={{ backgroundColor: 'rgba(34,197,94,0.15)', color: '#16a34a', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 600 }}>public</span> | — | Community maintained |
+  </Tab>
+</Tabs>
+
+For the complete list of JSON-RPC methods, see the [EVM reference](/evm/reference).

--- a/evm/transactions.mdx
+++ b/evm/transactions.mdx
@@ -155,42 +155,42 @@ EVM transactions in Sei follow the Ethereum transaction format with standard pro
 
     ### JavaScript example with web3.js
 
+    <Info>
+      Public RPC endpoints such as `https://evm-rpc.sei-apis.com` do not manage or unlock accounts, so `eth_getAccounts` and `eth_sendTransaction` are not available. Sign transactions locally with a private key and broadcast the raw transaction instead.
+    </Info>
+
     ```javascript
-    // Example using web3.js to send a transaction
-    const Web3 = require('web3');
+    // Example using web3.js v4 to sign and broadcast a transaction.
+    // Public RPC endpoints do not manage accounts, so sign locally with a private key.
+    const { Web3 } = require('web3');
     const web3 = new Web3('https://evm-rpc.sei-apis.com');
 
+    // Load your account from a private key. Never hard-code keys — read from an env var.
+    const account = web3.eth.accounts.privateKeyToAccount(process.env.PRIVATE_KEY);
+
     async function sendTransaction() {
-      const accounts = await web3.eth.getAccounts();
-      const sender = accounts[0];
+      // Current nonce for the sender
+      const nonce = await web3.eth.getTransactionCount(account.address);
 
-      // Get the current nonce for the sender
-      const nonce = await web3.eth.getTransactionCount(sender);
-
-      // Get the current block to estimate gas fees
+      // Use the latest base fee to set EIP-1559 fees
       const block = await web3.eth.getBlock('latest');
-      const baseFeePerGas = block.baseFeePerGas;
-
-      // Set priority fee (tip)
       const maxPriorityFeePerGas = web3.utils.toWei('1', 'gwei');
-
-      // Calculate max fee per gas
-      const maxFeePerGas = web3.utils
-        .toBN(baseFeePerGas)
-        .add(web3.utils.toBN(maxPriorityFeePerGas));
+      const maxFeePerGas = (BigInt(block.baseFeePerGas) + BigInt(maxPriorityFeePerGas)).toString();
 
       const tx = {
-        from: sender,
+        from: account.address,
         to: '0x07a565b7ed7d7a678680a4c162885bedbb695fe0',
         value: web3.utils.toWei('0.1', 'ether'),
         gas: 21000, // Gas limit for a simple transfer
-        maxFeePerGas: maxFeePerGas.toString(),
-        maxPriorityFeePerGas: maxPriorityFeePerGas,
-        nonce: nonce,
-        data: '0x' // Empty data for a simple transfer
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        nonce,
+        chainId: 1329 // pacific-1 mainnet (use 1328 for atlantic-2 testnet)
       };
 
-      const receipt = await web3.eth.sendTransaction(tx);
+      // Sign locally, then broadcast the raw transaction
+      const signed = await web3.eth.accounts.signTransaction(tx, process.env.PRIVATE_KEY);
+      const receipt = await web3.eth.sendSignedTransaction(signed.rawTransaction);
       console.log('Transaction receipt:', receipt);
     }
 

--- a/learn/dev-chains.mdx
+++ b/learn/dev-chains.mdx
@@ -20,6 +20,9 @@ applications and activities.
 - **Purpose**: Production
 - **Chain ID**: `pacific-1`
 - **EVM Chain ID**: `1329` or `0x531`
+- **EVM RPC**: `https://evm-rpc.sei-apis.com`
+- **WebSocket**: `wss://evm-ws.sei-apis.com`
+- **Explorer**: `https://seiscan.io`
 
 <iframe
   src="https://sei-widgets.vercel.app/add-sei?network=mainnet&label=Add+Sei+Mainnet+to+your+wallet"
@@ -38,6 +41,9 @@ applications work as expected before going live.
 - **Purpose**: Staging
 - **Chain ID**: `atlantic-2`
 - **EVM Chain ID**: `1328` or `0x530`
+- **EVM RPC**: `https://evm-rpc-testnet.sei-apis.com`
+- **WebSocket**: `wss://evm-ws-testnet.sei-apis.com`
+- **Explorer**: `https://testnet.seiscan.io`
 
 <iframe
   src="https://sei-widgets.vercel.app/add-sei?network=testnet&label=Add+Sei+Testnet+to+your+wallet"


### PR DESCRIPTION
## Summary

Improvements surfaced by an AI-agent scan of the docs. The recurring theme was that key information (RPC endpoints) was only available inside JavaScript widgets — invisible to non-JS readers and AI agents — plus one runnable-code bug.

## What's changed

**Discoverability**
- **`learn/dev-chains`** — EVM RPC, WebSocket, and explorer endpoints are now listed in plain text alongside the existing "add to wallet" widgets.
- **`evm/index`** — the RPC-selector iframe is replaced with a native endpoint table (official + community endpoints, per network), readable without executing JavaScript.
- **`docs.json`** — `/learn/getting-started` and `/evm/getting-started` (common guessed URLs that 404'd) now redirect to `/learn`.

**Correctness**
- **`evm/transactions`** — the only end-to-end "send a transaction" sample used `web3.eth.getAccounts()` + `eth_sendTransaction`, which public RPC endpoints don't support (they don't expose node-managed accounts), so it couldn't run as written. Replaced with local signing (`privateKeyToAccount` → `signTransaction` → `sendSignedTransaction`) using current web3.js v4 APIs.

**Completeness**
- **`evm/evm-parity/examples/ethers-quickstart` & `viem-quickstart`** — each read example now shows expected stdout ("You're done when you see…"), labels the credential-free read path as the first milestone, and adds a short Python (`web3.py`) snippet since Sei is EVM-compatible.
- **`evm/building-a-frontend`** — the contract-deploy prerequisite is now linked inline where `TOKEN_CONTRACT_ADDRESS` is introduced (Hardhat / Foundry / wizard).

## Testing
- `mint broken-links` passes.
- All changed pages compile and render under `mint dev`.

All endpoint values and chain IDs are taken verbatim from the existing network widgets / `llms.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
