### PR TITLE
docs: fix broken external links (#20)

### DIFF
--- a/ai/x402.mdx
+++ b/ai/x402.mdx
@@ -30,23 +30,23 @@ The x402 protocol enables a wide range of monetization strategies for web servic
 
 ## sei-js Integration
 
-The `sei-js` library provides a suite of packages to simplify working with x402 on Sei. You can find more details in the [sei-js x402 documentation](https://sei-js.docs.sei.io/x402/introduction).
+The `sei-js` library provides a suite of packages to simplify working with x402 on Sei. You can find more details in the [sei-js x402 repository](https://github.com/sei-protocol/sei-x402).
 
 ### Core Concepts
 
-- [**Protocol Overview**](https://sei-js.docs.sei.io/x402/overview): Learn about the architecture of x402.
-- [**Quickstart Guide**](https://sei-js.docs.sei.io/x402/quickstart): Build your first paid API.
-- [**Facilitators**](https://sei-js.docs.sei.io/x402/facilitators/introduction): Understanding payment facilitators.
-- [**Client Integration**](https://sei-js.docs.sei.io/x402/clients/fetch): How to integrate x402 in your frontend.
+- [**Protocol Overview**](https://github.com/sei-protocol/sei-x402/blob/main/docs/core-concepts/client-server.md): Learn about the architecture of x402.
+- [**Quickstart Guide**](https://github.com/sei-protocol/sei-x402/blob/main/docs/getting-started/quickstart-for-sellers.md): Build your first paid API.
+- [**Facilitators**](https://github.com/sei-protocol/sei-x402/blob/main/docs/core-concepts/facilitator.md): Understanding payment facilitators.
+- [**Client Integration**](https://github.com/sei-protocol/sei-x402/blob/main/docs/getting-started/quickstart-for-buyers.md): How to integrate x402 in your frontend.
 
 ### Available Packages
 
-- [**x402**](https://sei-js.docs.sei.io/x402/packages/x402): The core protocol implementation.
-- [**x402-fetch**](https://sei-js.docs.sei.io/x402/packages/x402-fetch): A fetch wrapper for making x402-compliant requests.
-- [**x402-axios**](https://sei-js.docs.sei.io/x402/packages/x402-axios): Axios interceptors for x402 payments.
-- [**x402-express**](https://sei-js.docs.sei.io/x402/packages/x402-express): Express middleware for serving paid content.
-- [**x402-hono**](https://sei-js.docs.sei.io/x402/packages/x402-hono): Middleware for Hono applications.
-- [**x402-next**](https://sei-js.docs.sei.io/x402/packages/x402-next): Components and utilities for Next.js applications.
+- [**x402**](https://www.npmjs.com/package/@sei-js/x402): The core protocol implementation.
+- [**x402-fetch**](https://www.npmjs.com/package/@sei-js/x402-fetch): A fetch wrapper for making x402-compliant requests.
+- [**x402-axios**](https://www.npmjs.com/package/@sei-js/x402-axios): Axios interceptors for x402 payments.
+- [**x402-express**](https://www.npmjs.com/package/@sei-js/x402-express): Express middleware for serving paid content.
+- [**x402-hono**](https://www.npmjs.com/package/@sei-js/x402-hono): Middleware for Hono applications.
+- [**x402-next**](https://www.npmjs.com/package/@sei-js/x402-next): Components and utilities for Next.js applications.
 
 These packages help streamline both the client-side (paying) and server-side (charging) aspects of the protocol.
 
@@ -416,5 +416,5 @@ Please try again or check your wallet balance for USDC tokens needed for the pay
 
 ## Tutorials & Resources
 
-- **[Sei-js X402 Documentation](https://sei-js.docs.sei.io/x402/introduction)**: Comprehensive guide on using the x402 protocol with the sei-js library, including package details and examples.
+- **[Sei-js X402 Repository](https://github.com/sei-protocol/sei-x402)**: Comprehensive guide on using the x402 protocol with the sei-js library, including package details and examples.
 - **[AxiomKit X402 Demo Repository](https://github.com/AxiomKit/axiomkit-showcase)**: The complete source code for the Axiom integration demo used in this guide, including installation and configuration instructions.

--- a/evm/usdc-on-sei.mdx
+++ b/evm/usdc-on-sei.mdx
@@ -22,7 +22,7 @@ This guide walks you through building a standalone index.js script using **Viem*
 - Node.js v18+ with "type": "module" in package.json
 - viem and dotenv installed
 - Sei wallet with USDC and SEI for gas on your selected network (default: testnet).
-- To get testnet USDC on Sei, use the [Circle Faucet](https://faucet.circle.com) or use [Circle’s CCTP v2](https://replit.com/@buildoncircle/cctp-v2-web-app?v=1#README.md) Sample application to transfer USDC cross-chain to your Sei wallet.
+- To get testnet USDC on Sei, use the [Circle Faucet](https://faucet.circle.com) or use [Circle’s CCTP v2](https://github.com/circlefin/circle-cctp-crosschain-transfer) Sample application to transfer USDC cross-chain to your Sei wallet.
 - Private key and recipient address stored in a .env file
 - Optional: set `SEI_NETWORK=testnet|mainnet` (defaults to `testnet`)
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -21,8 +21,10 @@ timeout = 20
 # A real browser UA avoids naive bot-blocks.
 user_agent = "Mozilla/5.0 (compatible; lychee link checker; +https://github.com/sei-protocol/sei-docs)"
 
-# Treat rate-limiting / bot-challenge responses as OK rather than broken.
-accept = ["200..=206", "301", "302", "304", "403", "429"]
+# Treat rate-limiting / bot-challenge responses as OK rather than broken. 405
+# (Method Not Allowed) covers JSON-RPC endpoints like evm-rpc.sei-apis.com that
+# reject the checker's GET but are very much alive.
+accept = ["200..=206", "301", "302", "304", "403", "405", "429"]
 
 # Don't flag these — local/example hosts and domains that hard-block automated
 # requests (so a failure here is a false positive, not real rot).
@@ -39,6 +41,13 @@ exclude = [
   "^https?://(www\\.)?linkedin\\.com",
   "^https?://(www\\.)?reddit\\.com",
   "^https?://(t\\.me|discord\\.gg|discord\\.com)",
+  # Live sites that hard-block automated checkers (verified reachable in a browser):
+  #   silostaking.io      → 402 Payment Required to bots
+  #   dashboard.pimlico.io → 404 to bots (client-rendered app shell)
+  #   blog.thirdweb.com   → cert chain rejected by lychee's TLS, fine in browsers
+  "^https?://(www\\.)?silostaking\\.io",
+  "^https?://dashboard\\.pimlico\\.io",
+  "^https?://blog\\.thirdweb\\.com",
 ]
 
 # Don't check mailto: links (this is the default; set explicitly for clarity).


### PR DESCRIPTION
## What is the purpose of the change?

Correct existing documentation. Resolves the 23 broken external links flagged by the weekly lychee check in #20.

## Describe the changes to the documentation

The errors fall into two categories:

**Genuinely dead links — repointed to live, verified targets:**

- **`ai/x402.mdx`** — the entire `sei-js.docs.sei.io` subdomain was decommissioned (it now `301`-redirects to `docs.sei.io`, and the x402 pages were not migrated there), so all 12 links 404'd.
  - The 6 package links now point to their npm pages (`@sei-js/x402`, `-fetch`, `-axios`, `-express`, `-hono`, `-next` — all confirmed published).
  - The overview / quickstart / facilitators / client-integration links now point to the canonical [`sei-protocol/sei-x402`](https://github.com/sei-protocol/sei-x402) repo docs, where these packages now live.
- **`evm/usdc-on-sei.mdx`** — the Replit CCTP template 404'd, and the older `circlefin/cctp-sample-app` is archived. Repointed to Circle's actively-maintained [`circlefin/circle-cctp-crosschain-transfer`](https://github.com/circlefin/circle-cctp-crosschain-transfer) sample app.

**False positives — handled in `lychee.toml` (these sites are alive; they just block automated checkers):**

- Added `405` to accepted status codes. JSON-RPC endpoints like `evm-rpc.sei-apis.com` reject the checker's `GET` with 405 but are very much alive (405 = "alive, wrong method", never link rot). This clears the 405 errors across 7 files.
- Excluded `silostaking.io` (returns 402 to bots), `dashboard.pimlico.io` (returns 404 to bots — client-rendered app shell), and `blog.thirdweb.com` (valid cert in browsers, but lychee's TLS client rejects the chain). Each is documented with a comment, and the excludes are host-specific so nearby links such as `silostaking.gitbook.io` are still checked.

## Notes

- Verified locally with lychee 0.24.2 using the updated config against all 13 previously-failing files: **0 errors** (108 OK, 43 excluded as intended).
- `llms-full.txt` still contains the old URLs, but it is a generated artifact (built from the live site by `scripts/generate-llms.mjs`), is not scanned by lychee (`*.md`/`*.mdx` only), and refreshes automatically via the weekly regenerate workflow once these edits deploy — so no hand-editing is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)