### PR TITLE
docs: add Envio to EVM indexer providers

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -240,6 +240,7 @@
               {
                 "group": "Indexers",
                 "pages": [
+                  "evm/indexer-providers/envio",
                   "evm/indexer-providers/goldsky",
                   "evm/indexer-providers/the-graph",
                   "evm/indexer-providers/goldrush",

--- a/evm/indexer-providers/envio.mdx
+++ b/evm/indexer-providers/envio.mdx
@@ -1,0 +1,99 @@
+---
+title: 'Envio'
+description: 'Index Sei smart contract data using Envio, a modular hyper-performant data indexing solution.'
+keywords: ['envio', 'hyperindex', 'hypersync', 'hyperrpc', 'blockchain indexer', 'graphql', 'real-time data']
+---
+
+## Envio
+
+Index Sei smart contract data using Envio, a modular hyper-performant data indexing solution. Envio offers three products you can use individually or together to fit your data needs on Sei.
+
+1. [HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview), a fully customizable blockchain indexing framework that powers GraphQL APIs over Postgres
+2. [HyperSync](https://docs.envio.dev/docs/HyperSync/overview), a real-time data retrieval layer up to 2000x faster than traditional RPC
+3. [HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc), an extremely fast RPC for data-intensive queries
+
+> **New to Envio?** Jump straight to [How to Index Sei Smart Contract Data in Minutes using Envio](https://docs.envio.dev/blog/index-sei-smart-contracts-envio) for a step-by-step walkthrough that builds a USDC indexer on Sei in under five minutes.
+
+| Field                  | Value                                                                |
+| ---------------------- | -------------------------------------------------------------------- |
+| Sei Chain ID           | 1329                                                                 |
+| HyperSync URL Endpoint | `https://sei.hypersync.xyz` or `https://1329.hypersync.xyz`          |
+| HyperRPC URL Endpoint  | `https://sei.rpc.hypersync.xyz` or `https://1329.rpc.hypersync.xyz`  |
+
+> Sei testnet is also supported, with HyperSync at [https://sei-testnet.hypersync.xyz](https://sei-testnet.hypersync.xyz) and HyperRPC at [https://sei-testnet.rpc.hypersync.xyz](https://sei-testnet.rpc.hypersync.xyz).
+
+## Choosing a Product
+
+### HyperIndex
+
+**Best for:** projects that need a complete indexing solution with schema management, event handling, and a GraphQL API.
+
+* A full-featured indexing framework that transforms on-chain events into structured, queryable databases with GraphQL APIs
+* Configured with a YAML file, a GraphQL schema, and TypeScript, JavaScript, or ReScript event handlers
+* Supports multichain indexing, real-time indexing, reorg support, and factory (dynamic) contracts
+* Powered by HyperSync for historical backfill
+
+### HyperSync
+
+**Best for:** new projects designing their own data access layer, performance-critical workloads, advanced filtering, and full control over data formatting.
+
+* A purpose-built, high-performance data retrieval layer, built from the ground up in Rust as an alternative to traditional JSON-RPC endpoints
+* The raw blockchain data access layer that powers HyperIndex, delivering up to 2000x faster performance than traditional RPC endpoints
+* Client libraries available for Python, Rust, Node.js, and Go
+* Filter, select, and process exactly the data you need with powerful query options
+
+Common use cases include custom indexers, data analytics, block explorers, monitoring tools, cross-chain applications, and ETL pipelines.
+
+### HyperRPC
+
+**Best for:** drop-in replacements for existing RPC-based code, projects that need standard JSON-RPC interfaces, and teams without time for a deeper integration.
+
+* An extremely fast RPC designed specifically for data-intensive blockchain tasks
+* A specialized JSON-RPC endpoint optimized for data retrieval workflows
+* Drop-in compatible with existing tooling that uses standard RPC methods
+* Up to 5x faster than traditional nodes for data-intensive operations; uses HyperSync to fulfill requests
+
+Common use cases include historical data queries, log event filtering, block and transaction retrievals, and analytics applications.
+
+## Getting Started
+
+Make sure you have installed the [prerequisites](https://docs.envio.dev/docs/HyperIndex/quickstart#prerequisites), then initialize a new indexer.
+
+```bash theme={"dark"}
+pnpx envio init
+```
+
+You'll follow interactive prompts to customize your indexer for Sei. A minimal Sei `config.yaml` looks like this.
+
+```yaml theme={"dark"}
+name: IndexerName
+description: Indexer Description
+chains:
+  - id: 1329 # Sei
+    start_block: START_BLOCK_NUMBER
+    contracts:
+      - name: ContractName
+        address:
+          - "0xYourContractAddress1"
+        events:
+          - event: Event
+```
+
+For more detail on configuring chains, schemas, and event handlers, see the [HyperIndex configuration guide](https://docs.envio.dev/docs/HyperIndex/configuration-file) and [Indexing Sei on Envio](https://docs.envio.dev/docs/HyperIndex/sei).
+
+## Built with Envio
+
+* [Indexer Explorer](https://envio.dev/explorer), browse public real-time indexers built on Envio
+* [Case studies](https://docs.envio.dev/blog/tags/case-studies), see real-world deployments and migrations
+* [Showcase](https://docs.envio.dev/showcase), explore live demos built with HyperIndex and HyperSync
+
+## More Resources
+
+* [HyperIndex Quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart)
+* [Quickstart with AI](https://docs.envio.dev/docs/HyperIndex/quickstart-with-ai)
+* [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service)
+* [GitHub](https://github.com/enviodev/hyperindex)
+
+## Support
+
+Need help? Connect with the Envio team on [Discord](https://discord.gg/envio) or [Telegram](https://t.me/+kAIGElzPjApiMjI0).


### PR DESCRIPTION
## Summary

Adds a new page at `evm/indexer-providers/envio` covering Envio's three products (HyperIndex, HyperSync, HyperRPC), with a Sei-specific `config.yaml` snippet and a link to the Sei USDC indexing tutorial.

One-line addition to `docs.json` adds the page to the Indexers nav group.

## Notes

- Mirrors the structure and frontmatter style of the existing provider pages (Goldsky, The Graph, etc.)
- Sei chain ID and HyperSync/HyperRPC endpoints for mainnet (1329) and testnet (1328) are included in the endpoints table