### PR TITLE
Gem Wallet natively supports both Sei and Sei EVM.

### DIFF
--- a/learn/wallets.mdx
+++ b/learn/wallets.mdx
@@ -38,6 +38,7 @@ different features and levels of security.
 | Privy | ✅ | Email / Social / Passkey / Wallet | 60 | Embedded | ✅ | [Privy](https://privy.io) |
 | Rabby | ✅ | Mnemonic / Priv/Passkey | 60 | Software | ✅ | [Rabby Wallet](https://chromewebstore.google.com/detail/rabby-wallet/acmacodkjbdgmoleebolmdjonilkdbch) |
 | OKX | ✅ | Mnemonic / Privkey | 118 / 60 | Software | ✅ | [OKX Wallet](https://www.okx.com/web3/wallet/sei) |
+| Gem Wallet | ✅ | Mnemonic / Privkey | 118 / 60 | Software | ✅ | [Gem Wallet](https://gemwallet.com/sei-wallet/) |
 
 Wallets with coin type 118 use the Cosmos HD derivation path; the same key still maps to a unique EVM `0x...` address via Sei's address-association system.
 


### PR DESCRIPTION
## What is the purpose of the change?

Add Gem Wallet to SEI recommended wallets at https://docs.sei.io/learn/wallets

## Describe the changes to the documentation

Added Gem Wallet to the list of and linked to https://gemwallet.com/sei-wallet/

## Notes
Gem Wallet has support for both SEI and SEI EVM
