### PR TITLE
docs: post-#27 follow-up — correctness fixes + Vale prose cleanup

### DIFF
--- a/.github/styles/Sei/Terminology.yml
+++ b/.github/styles/Sei/Terminology.yml
@@ -11,7 +11,9 @@ swap:
   'the Sei blockchain': Sei
   'Sei [Cc]hain': Sei
   'gas fees?': gas
-  '\bCW\b': CosmWasm
+  # Bare 'CW' is accepted shorthand for CosmWasm here — the standard names
+  # CW20/CW721/CW1155 plus phrases like "CW pointer", "CW-based", and "CW NFT".
+  # CosmWasm casing is still enforced by the rule below, so we don't flag bare CW.
   '[Cc]osmwasm': CosmWasm
   '[Mm]etamask': MetaMask
   'Sei-?[Jj][Ss]': sei-js

--- a/ai/cambrian-agent-kit.mdx
+++ b/ai/cambrian-agent-kit.mdx
@@ -51,7 +51,7 @@ This tutorial guides you through:
 - Node.js & npm installed
 - SEI wallet private key
 - OpenAI API key (for AI integrations)
-- **Minimum SEI balance**: Ensure you have sufficient SEI for gas fees
+- **Minimum SEI balance**: Ensure you have sufficient SEI for gas
 
 ### 2. Project Setup
 

--- a/ai/x402.mdx
+++ b/ai/x402.mdx
@@ -6,14 +6,14 @@ keywords: ['x402', 'micropayments', 'HTTP 402', 'API monetization', 'Sei', 'paym
 ---
 x402 Protocol brings HTTP micro payments to Sei, enabling you to monetize APIs, premium content, and digital services with instant, low-cost payments. Whether you're building AI APIs, data feeds, or premium content platforms, x402 makes it simple to add payment gates to any HTTP endpoint.
 
-**Works with Sei's advantages:** Sei's fast finality, low gas fees, and EVM compatibility make it perfect for micro payments. x402 leverages these features to enable seamless payment flows that complete in milliseconds.
+**Works with Sei's advantages:** Sei's fast finality, low gas, and EVM compatibility make it perfect for micro payments. x402 leverages these features to enable seamless payment flows that complete in milliseconds.
 
 
 <Info>
 
 **Why x402 on Sei?**
 
-- **Fast & Cheap Payments**: Sei's 400ms finality and low gas fees make micropayments practical. Perfect for pay-per-request APIs and streaming content.
+- **Fast & Cheap Payments**: Sei's 400ms finality and low gas make micropayments practical. Perfect for pay-per-request APIs and streaming content.
 - **EVM Compatible**: Use familiar tools like Viem, Ethers.js, and Hardhat. All existing Ethereum tooling works seamlessly on Sei.
 - **Built-in Wallet Support**: Integrates with Sei wallets, MetaMask, and any EIP-6963 compatible wallet for smooth user experiences.
 

--- a/evm/ai-tooling/cambrian-agent-kit.mdx
+++ b/evm/ai-tooling/cambrian-agent-kit.mdx
@@ -51,7 +51,7 @@ This tutorial guides you through:
 - Node.js & npm installed
 - SEI wallet private key
 - OpenAI API key (for AI integrations)
-- **Minimum SEI balance**: Ensure you have sufficient SEI for gas fees
+- **Minimum SEI balance**: Ensure you have sufficient SEI for gas
 
 ### 2. Project Setup
 

--- a/evm/bridging/layerzero.mdx
+++ b/evm/bridging/layerzero.mdx
@@ -20,7 +20,7 @@ This guide provides a comprehensive, step-by-step tutorial for integrating Layer
 
 - Basic knowledge of Solidity and smart contracts
 - Node.js and npm installed
-- A wallet with SEI and other chain tokens for gas fees
+- A wallet with SEI and other chain tokens for gas
 - Familiarity with Hardhat or Foundry
 
 ## What is LayerZero?

--- a/evm/differences-with-ethereum.mdx
+++ b/evm/differences-with-ethereum.mdx
@@ -80,7 +80,7 @@ Sei EVM was originally deployed at the following block heights and versions:
 ### PREVRANDAO
 
 Since Sei doesn't rely on the same pseudo‑randomness way of determining the next
-validator like Proof of Stake (PoS) Ethereum does, it doesn't really have the
+validator like Proof of Stake (PoS) Ethereum does, it doesn't have the
 "randomness" artifact that can be set as `PREVRANDAO`'s return value. On Sei,
 `PREVRANDAO` returns a value derived from the current block time. For strong
 randomness needs in contract logic, use a verifiable randomness oracle (as is
@@ -150,7 +150,7 @@ state would be marked "pending" until the node is accepted by other nodes).
 
 However, on Sei, the block proposer would broadcast first and only execute the
 proposal if it's accepted (i.e. every node would execute the block at roughly
-the same time), so Sei does not really have a window when "pending state"
+the same time), so Sei does not have a window when "pending state"
 exists.
 
 ## Gas Model & Fees

--- a/evm/evm-foundry.mdx
+++ b/evm/evm-foundry.mdx
@@ -33,7 +33,7 @@ Before we begin, ensure you have the following:
 
 - [Foundry](https://book.getfoundry.sh/) installed on your system
 - A basic understanding of Solidity and smart contract development
-- A wallet with SEI tokens for gas fees
+- A wallet with SEI tokens for gas
 - [Node.js](https://nodejs.org/) (v18.0.0 or later) for ethers.js interactions
 
 ## Setting Up Your Development Environment

--- a/evm/evm-hardhat.mdx
+++ b/evm/evm-hardhat.mdx
@@ -283,7 +283,7 @@ Create a deployment script `deploy-sei-nft.ts`:
 import { network } from 'hardhat';
 
 // Hardhat 3 exposes ethers through a network connection rather than a global import
-const { ethers } = await network.getOrCreate();
+const { ethers } = await network.create();
 
 const [deployer] = await ethers.getSigners();
 console.log('Deploying contracts with the account:', deployer.address);
@@ -395,7 +395,7 @@ Now create a deployment script `scripts/deploy-upgradeable-token.ts`. It deploys
 ```typescript title="scripts/deploy-upgradeable-token.ts"
 import { network } from 'hardhat';
 
-const { ethers } = await network.getOrCreate();
+const { ethers } = await network.create();
 
 const [deployer] = await ethers.getSigners();
 console.log('Deploying contracts with the account:', deployer.address);
@@ -459,7 +459,7 @@ Now, create an upgrade script `scripts/upgrade-token.ts`. **Replace `PROXY_ADDRE
 ```typescript title="scripts/upgrade-token.ts"
 import { network } from 'hardhat';
 
-const { ethers } = await network.getOrCreate();
+const { ethers } = await network.create();
 
 // !! REPLACE WITH YOUR PROXY ADDRESS from the deploy step !!
 const PROXY_ADDRESS = '0xYOUR_PROXY_CONTRACT_ADDRESS_HERE';
@@ -509,7 +509,7 @@ describe('SeiToken', function () {
 
   beforeEach(async function () {
     // Hardhat 3 exposes ethers through a network connection
-    ({ ethers } = await network.getOrCreate());
+    ({ ethers } = await network.create());
 
     // Get signers
     [owner, addr1, addr2] = await ethers.getSigners();

--- a/evm/evm-hardhat.mdx
+++ b/evm/evm-hardhat.mdx
@@ -580,7 +580,7 @@ npx hardhat test
 
 Once you've tested your contracts, you can deploy them to the Sei testnet or mainnet. To deploy, you'll need:
 
-1. SEI tokens in your wallet for gas fees
+1. SEI tokens in your wallet for gas
 2. Your private key stored in the encrypted keystore (`npx hardhat keystore set SEI_PRIVATE_KEY`) — or exported as a `SEI_PRIVATE_KEY` environment variable in CI
 
 Deploy to the testnet:

--- a/evm/indexer-providers/moralis.mdx
+++ b/evm/indexer-providers/moralis.mdx
@@ -336,7 +336,7 @@ main();
 
 ## Working with Testnet
 
-<Warning>To switch to Sei testnet, simply change the chain ID in your API calls.</Warning>
+<Warning>To switch to Sei testnet, change the chain ID in your API calls.</Warning>
 
 ```typescript
 // Testnet configuration

--- a/evm/indexer-providers/the-graph.mdx
+++ b/evm/indexer-providers/the-graph.mdx
@@ -64,7 +64,7 @@ You'll be prompted to provide some info on your subgraph like this:
 ![CLI sample](/assets/ecosystem/resources/the-graph/cli_sample.png)
 *CLI*
 
-Simply have your contract verified on the block explorer and the CLI will
+Have your contract verified on the block explorer and the CLI will
 automatically obtain the ABI and set up your subgraph. The default settings will
 generate an entity for each event.
 
@@ -142,7 +142,7 @@ by Messari:
 The query URL for this subgraph is:
 `https://gateway-arbitrum.network.thegraph.com/api/`**[api-key]**`/subgraphs/id/HdVdERFUe8h61vm2fDyycHgxjsde5PbB832NHgJfZNqK`
 
-Now, you simply need to fill in your own API Key to start sending GraphQL
+Now, you need to fill in your own API Key to start sending GraphQL
 queries to this endpoint.
 
 ### Getting your own API Key

--- a/evm/precompiles/cosmwasm-precompiles/addr.mdx
+++ b/evm/precompiles/cosmwasm-precompiles/addr.mdx
@@ -94,7 +94,7 @@ Before getting started, ensure you have:
 - **Node.js** (v18 or higher)
 - **npm** or **yarn** package manager
 - **EVM-compatible wallet**
-- **SEI tokens** for gas fees
+- **SEI tokens** for gas
 - **Hardhat** development environment set up
 
 #### Install Dependencies

--- a/evm/precompiles/cosmwasm-precompiles/bank.mdx
+++ b/evm/precompiles/cosmwasm-precompiles/bank.mdx
@@ -123,7 +123,7 @@ Before getting started, ensure you have:
 - **Node.js** (v18 or higher)
 - **npm** or **yarn** package manager
 - **EVM-compatible wallet**
-- **SEI tokens** for gas fees and testing transfers
+- **SEI tokens** for gas and testing transfers
 - **Hardhat** for development and testing
 
 #### Install Dependencies

--- a/evm/precompiles/cosmwasm-precompiles/bank.mdx
+++ b/evm/precompiles/cosmwasm-precompiles/bank.mdx
@@ -300,7 +300,7 @@ try {
   });
 
   const receipt = await tx.wait();
-  console.log('Native SEI transfer successful:', receipt.transactionHash);
+  console.log('Native SEI transfer successful:', receipt.hash);
   console.log(`Sent ${amountInSei} SEI to ${recipientAddress}`);
 } catch (error) {
   console.error('Native SEI transfer failed:', error);
@@ -357,7 +357,7 @@ const tx = await bank.send(
 );
 
 const receipt = await tx.wait();
-console.log('Custom token transfer successful:', receipt.transactionHash);
+console.log('Custom token transfer successful:', receipt.hash);
 console.log(`Sent ${amount} ${tokenDenom} from ${fromAddress} to ${toAddress}`);
 ```
 
@@ -643,16 +643,16 @@ class SeiTokenManager {
   // Send native SEI tokens
   async sendSei(recipientAddress: string, amountInSei: string) {
     try {
-      const amountInUsei = ethers.parseUnits(amountInSei, 18);
+      const amountInWei = ethers.parseUnits(amountInSei, 18);
       const tx = await this.bank.sendNative(recipientAddress, {
-        value: amountInUsei,
+        value: amountInWei,
         gasLimit: 100000
       });
 
       const receipt = await tx.wait();
       return {
         success: true,
-        transactionHash: receipt.transactionHash,
+        transactionHash: receipt.hash,
         amount: amountInSei,
         recipient: recipientAddress
       };
@@ -715,7 +715,7 @@ class SeiTokenManager {
       const receipt = await tx.wait();
       return {
         success: true,
-        transactionHash: receipt.transactionHash,
+        transactionHash: receipt.hash,
         from: fromAddress,
         to: toAddress,
         denom,

--- a/evm/precompiles/cosmwasm-precompiles/cosmwasm.mdx
+++ b/evm/precompiles/cosmwasm-precompiles/cosmwasm.mdx
@@ -95,7 +95,7 @@ Before getting started, ensure you have:
 - **Node.js** (v18 or higher)
 - **npm** or **yarn** package manager
 - **EVM-compatible wallet**
-- **SEI tokens** for gas fees and contract operations
+- **SEI tokens** for gas and contract operations
 
 #### Install Dependencies
 

--- a/evm/precompiles/governance.mdx
+++ b/evm/precompiles/governance.mdx
@@ -112,7 +112,7 @@ Before getting started, ensure you have:
 - **Node.js** (v18 or higher)
 - **npm** or **yarn** package manager
 - **MetaMask** or compatible EVM wallet configured for Sei Mainnet
-- **SEI tokens** for gas fees and governance deposits (minimum 3,500 SEI for proposals)
+- **SEI tokens** for gas and governance deposits (minimum 3,500 SEI for proposals)
 
 #### Install Dependencies
 
@@ -148,7 +148,7 @@ Purchase SEI tokens from supported exchanges:
 - **Decentralized Exchanges:** Astroport, Dragonswap (on Sei)
 - **Bridge Options:** Various cross-chain bridges support SEI
 
-<Warning>**Minimum Requirements:** You need at least 3,500 SEI to submit a governance proposal, plus additional tokens for gas fees and potential additional deposits.</Warning>
+<Warning>**Minimum Requirements:** You need at least 3,500 SEI to submit a governance proposal, plus additional tokens for gas and potential additional deposits.</Warning>
 
 ### Contract Initialization
 
@@ -900,7 +900,7 @@ PRIVATE_KEY=your_private_key_here
 5. **Ensure you have sufficient SEI:**
 
    - Minimum 3,500 SEI for proposal deposit
-   - Additional SEI for gas fees and optional additional deposits
+   - Additional SEI for gas and optional additional deposits
    - Staked SEI for voting power
 
 6. **Run the script:**

--- a/evm/precompiles/json.mdx
+++ b/evm/precompiles/json.mdx
@@ -72,7 +72,7 @@ Before getting started, ensure you have:
 - **Node.js** (v18 or higher)
 - **npm** or **yarn** package manager
 - **MetaMask** or compatible EVM wallet configured for Sei Mainnet
-- **SEI tokens** for gas fees
+- **SEI tokens** for gas
 
 #### Install Dependencies
 
@@ -518,7 +518,7 @@ PRIVATE_KEY=your_private_key_here
 
 5. **Ensure you have SEI tokens:**
 
-   - SEI for gas fees (small amounts needed for view functions)
+   - SEI for gas (small amounts needed for view functions)
 
 6. **Run the script:**
 

--- a/evm/precompiles/staking.mdx
+++ b/evm/precompiles/staking.mdx
@@ -457,7 +457,7 @@ Before getting started, ensure you have:
 - **Node.js** (v18 or higher)
 - **npm** or **yarn** package manager
 - **EVM-compatible wallet**
-- **SEI tokens** for gas fees and staking operations
+- **SEI tokens** for gas and staking operations
 
 #### Install Dependencies
 

--- a/evm/sei-global-wallet.mdx
+++ b/evm/sei-global-wallet.mdx
@@ -8,7 +8,7 @@ keywords: ['sei global wallet', 'embedded wallet', 'EIP-6963', 'wallet integrati
 
 Sei Global Wallet is a cross-application embedded crypto wallet powered by [Dynamic Global Wallets](https://www.dynamic.xyz/docs/react/global-wallets/overview). It gives users a persistent wallet experience across any integrated app within the Sei ecosystem, allowing them to authenticate and interact using familiar login methods like Google, Twitter, or Telegram—no browser extension or prior crypto knowledge required.
 
-<Info>Additional auth methods such as existing wallet apps (Metamask, ..) are possible through Dynamic, but are not currently enabled</Info>
+<Info>Additional auth methods such as existing wallet apps (MetaMask, ..) are possible through Dynamic, but are not currently enabled</Info>
 
 ## What is Sei Global Wallet?
 
@@ -65,7 +65,7 @@ Import the package to register the wallet:
 import '@sei-js/sei-global-wallet/eip6963';
 ```
 
-<Warning>**Important:** Simply importing the package registers the wallet for discovery, but you'll need to ensure your application's provider stack is properly configured to interact with it. Most wallet connection libraries that support EIP-6963 will automatically detect the wallet after import.</Warning>
+<Warning>**Important:** Importing the package registers the wallet for discovery, but you'll need to ensure your application's provider stack is properly configured to interact with it. Most wallet connection libraries that support EIP-6963 will automatically detect the wallet after import.</Warning>
 
 ---
 

--- a/evm/sei-js/index.mdx
+++ b/evm/sei-js/index.mdx
@@ -14,7 +14,7 @@ keywords: ['sei-js', 'typescript', 'sdk', 'sei network', 'evm', 'precompiles', '
 
 - **Complete TypeScript support** — Full type safety for every function, contract interaction, and API response. Catch errors at compile time.
 - **Production ready** — Battle-tested components used by major applications in the Sei ecosystem.
-- **Optimized for Sei** — Take advantage of Sei's fast finality, low gas fees, and native features.
+- **Optimized for Sei** — Take advantage of Sei's fast finality, low gas, and native features.
 
 ## Package Ecosystem
 

--- a/evm/transactions-with-seid.mdx
+++ b/evm/transactions-with-seid.mdx
@@ -261,7 +261,7 @@ seid tx evm send 0x... 1000000000000000000 \
 <Warning>
 **Common Issues:**
 
-- Insufficient balance for transaction + gas fees
+- Insufficient balance for transaction + gas
 - Incorrect address formats (use 0x prefix for EVM addresses)
 - Gas limit too low for complex operations
 - Nonce conflicts in rapid successive transactions
@@ -279,7 +279,7 @@ seid tx evm send 0x... 1000000000000000000 \
 ## Transaction Requirements
 
 - **Key Configuration**: Local keyring must contain the signing key
-- **Sufficient Balance**: Account must have enough tokens for transaction amount + gas fees
+- **Sufficient Balance**: Account must have enough tokens for transaction amount + gas
 - **Address Formats**: Use proper formats (0x... for EVM, seivaloper... for validators)
 - **Network Access**: Ensure connectivity to the specified RPC endpoint
 - **Gas Limits**: Set appropriate gas limits for transaction complexity

--- a/evm/transactions.mdx
+++ b/evm/transactions.mdx
@@ -58,7 +58,7 @@ EVM transactions in Sei follow the Ethereum transaction format with standard pro
     | `nonce` | A sequentially incrementing counter that indicates the transaction number from the account. This prevents replay attacks and ensures transaction ordering. |
     | `data` | The input data (also called 'input' or 'calldata') for contract execution. For simple transfers, this is usually empty. For contract interactions, this contains the function selector and encoded arguments. |
     | `value` | Amount of SEI to transfer from sender to recipient (denominated in WEI, where 1 SEI equals 1e+18 WEI). |
-    | `gasLimit` | The maximum amount of gas units that can be consumed by the transaction. Often referred to simply as 'gas' in transaction objects. |
+    | `gasLimit` | The maximum amount of gas units that can be consumed by the transaction. Often referred to as 'gas' in transaction objects. |
     | `maxPriorityFeePerGas` | The maximum price of the consumed gas to be included as a tip to the validator (denominated in WEI). Used in EIP-1559 transactions. |
     | `maxFeePerGas` | The maximum fee per unit of gas willing to be paid for the transaction (inclusive of baseFeePerGas and maxPriorityFeePerGas). Used in EIP-1559 transactions. |
     | `gasPrice` | The price per unit of gas the sender is willing to pay (denominated in WEI). Used in legacy transactions. |

--- a/evm/wallet-integrations/pimlico.mdx
+++ b/evm/wallet-integrations/pimlico.mdx
@@ -219,7 +219,7 @@ You've now learned how to:
 - Create a smart account
 - Send gasless transactions
 
-This implementation enables a seamless user experience where end users don't need to worry about gas fees or managing native tokens to interact with your dApp.
+This implementation enables a seamless user experience where end users don't need to worry about gas or managing native tokens to interact with your dApp.
 
 For more information about Pimlico and its features, check out:
 

--- a/evm/wallet-integrations/thirdweb.mdx
+++ b/evm/wallet-integrations/thirdweb.mdx
@@ -355,7 +355,7 @@ npm run dev
 1. Open your browser and navigate to `http://localhost:5173`
 2. Click "Connect to Sei Network"
 3. Choose your preferred login method (Google, email, etc.)
-4. A smart wallet is automatically created for you (no gas fees!)
+4. A smart wallet is automatically created for you (no gas!)
 5. After connecting, you'll see three interaction buttons
 6. Try storing number 37 or a custom number
 7. Retrieve the stored value - all transactions are gasless!

--- a/learn/accounts.mdx
+++ b/learn/accounts.mdx
@@ -93,7 +93,7 @@ This method directly uses the private key to interact with the network.
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { seiTestnet } from 'viem/chains';
-import { ADDRESS_PRECOMPILE_ABI, ADDRESS_PRECOMPILE_ADDRESS } from '@sei-js/evm';
+import { ADDRESS_PRECOMPILE_ABI, ADDRESS_PRECOMPILE_ADDRESS } from '@sei-js/precompiles';
 
 const PRIVATE_KEY = '<replace_with_private_key>';
 
@@ -127,7 +127,7 @@ account.
 import { createWalletClient, http, parseSignature, toHex } from 'viem';
 import { privateKeyToAccount, generatePrivateKey } from 'viem/accounts';
 import { seiTestnet } from 'viem/chains';
-import { ADDRESS_PRECOMPILE_ABI, ADDRESS_PRECOMPILE_ADDRESS } from '@sei-js/evm';
+import { ADDRESS_PRECOMPILE_ABI, ADDRESS_PRECOMPILE_ADDRESS } from '@sei-js/precompiles';
 
 const client = createWalletClient({ chain: seiTestnet, transport: http() });
 
@@ -166,7 +166,7 @@ import secp256k1 from 'secp256k1';
 import { createWalletClient, http } from 'viem';
 import { privateKeyToAccount, generatePrivateKey } from 'viem/accounts';
 import { seiTestnet } from 'viem/chains';
-import { ADDRESS_PRECOMPILE_ABI, ADDRESS_PRECOMPILE_ADDRESS } from '@sei-js/evm';
+import { ADDRESS_PRECOMPILE_ABI, ADDRESS_PRECOMPILE_ADDRESS } from '@sei-js/precompiles';
 
 const client = createWalletClient({ chain: seiTestnet, transport: http() });
 

--- a/learn/general-governance.mdx
+++ b/learn/general-governance.mdx
@@ -85,7 +85,7 @@ Validators and delegators can split their voting power across multiple options u
 
 Guidelines for effective governance participation.
 
-- **Research Thoroughly** — Read proposals completely and understand their implications before voting.
+- **Research Thoroughly** — Read proposals and understand their implications before voting.
 - **Engage in Discussion** — Participate in community forums and discussions to better understand different perspectives.
 - **Vote Responsibly** — Consider the long-term implications of proposals for the network and ecosystem.
 - **Stay Informed** — Follow governance updates and participate actively in the democratic process.

--- a/learn/general-staking.mdx
+++ b/learn/general-staking.mdx
@@ -21,7 +21,7 @@ validator's weight is based on the number of tokens delegated to them plus their
 own stake.
 
 The Sei protocol incentivizes validators and delegators with staking rewards
-from gas fees and genesis token unlocks. All rewards are distributed
+from gas and genesis token unlocks. All rewards are distributed
 to delegators proportional to their delegation, and the validator keeps a percentage of this as commission.
 Users can view a validator's commission rate on the Sei Dashboard, or by querying the validator information on-chain.
 

--- a/learn/parallelization-engine.mdx
+++ b/learn/parallelization-engine.mdx
@@ -84,7 +84,7 @@ The dependency analyzer might also consider secondary effects such as:
 
 The dependency generator outputs an estimated read/write set for each transaction. These sets contain the state keys expected to be accessed, with additional metadata indicating access types (read vs. write) and confidence levels for each prediction. The system uses these confidence levels during scheduling decisions to minimize the likelihood of conflicts.
 
-The output from this phase consists of an "estimated writeset" for each transaction—essentially a prediction of its state impact—which serves as crucial input for the next execution planning phase.
+The output from this phase consists of an "estimated writeset" for each transaction—a prediction of its state impact—which serves as crucial input for the next execution planning phase.
 
 ### 3. Parallel Execution
 
@@ -178,7 +178,7 @@ The system must identify and resolve any conflicts that emerge during and after 
 The OCC approach includes a critical safety mechanism for situations where parallel execution cannot succeed:
 
 1. **Failure Detection**: The system detects failure conditions when parallel execution encounters excessive conflicts or critical errors.
-2. **State Rollback**: All state changes from the failed parallel attempt are completely discarded.
+2. **State Rollback**: All state changes from the failed parallel attempt are discarded.
 3. **Sequential Reprocessing**: The entire transaction batch undergoes sequential processing as a fallback.
 
 This fallback guarantees that the blockchain can always make progress, even in worst-case scenarios where parallelization proves ineffective for a particular block.

--- a/learn/pointers.mdx
+++ b/learn/pointers.mdx
@@ -11,7 +11,7 @@ keywords: ['pointer contracts', 'cross-vm interoperability', 'evm cosmos bridge'
 
 Pointer Contracts enable tokens to be used interoperably in both EVM and
 Cosmos environments. Intended to be efficient and quick to deploy, a pointer
-simply serves as an interpreter between the two "languages" used in either
+serves as an interpreter between the two "languages" used in either
 execution environment.
 
 ## Why Pointer Contracts

--- a/learn/twin-turbo-consensus.mdx
+++ b/learn/twin-turbo-consensus.mdx
@@ -6,7 +6,7 @@ keywords: ['twin turbo consensus', 'high-speed blockchain', 'transaction through
 ---
 ## Introduction
 
-Sei's consensus mechanism, often referred to as Twin Turbo Consensus, represents a suite of optimizations designed to achieve exceptionally low block finality times, targeting approximately 400 milliseconds. This rapid finality is not achieved through a completely novel consensus algorithm but rather through significant enhancements to the underlying Tendermint Byzantine Fault Tolerant (BFT) consensus engine, aggressive configuration tuning, and tight integration with Sei's parallel execution layer and SeiDB storage system. The goal is to provide near-instant transaction confirmation, enabling a new class of high-performance decentralized applications, particularly those built for the EVM.
+Sei's consensus mechanism, often referred to as Twin Turbo Consensus, represents a suite of optimizations designed to achieve exceptionally low block finality times, targeting approximately 400 milliseconds. This rapid finality is not achieved through a novel consensus algorithm but rather through significant enhancements to the underlying Tendermint Byzantine Fault Tolerant (BFT) consensus engine, aggressive configuration tuning, and tight integration with Sei's parallel execution layer and SeiDB storage system. The goal is to provide near-instant transaction confirmation, enabling a new class of high-performance decentralized applications, particularly those built for the EVM.
 
 ## Core Concept: Pipelined & Parallelized Consensus
 

--- a/learn/user-quickstart.mdx
+++ b/learn/user-quickstart.mdx
@@ -13,7 +13,7 @@ Download a compatible wallet such as [MetaMask](https://metamask.io/), [Rabby](h
 
 ## 2. Set Up and "Associate" Your Wallet
 
-Simply making a transaction will broadcast your public key to the chain, allowing full cross-environment functionality. If your wallet is not "associated" it simply means that the network is not aware that your key exists, and therefore it cannot be determined which two addresses are actually the same wallet due to the cryptographic algorithm by which the EVM wallet address is derived from the key(s).
+Making a transaction will broadcast your public key to the chain, allowing full cross-environment functionality. If your wallet is not "associated" it means that the network is not aware that your key exists, and therefore it cannot be determined which two addresses are actually the same wallet due to the cryptographic algorithm by which the EVM wallet address is derived from the key(s).
 
 <Info>
   Learn more about [how accounts work](/learn/accounts) on Sei.

--- a/node/advanced-config-monitoring.mdx
+++ b/node/advanced-config-monitoring.mdx
@@ -7,7 +7,7 @@ keywords: ['sei node', 'node monitoring', 'prometheus', 'grafana', 'performance 
 
 ## Optimizing System Configuration
 
-There are a virtually unlimited number of unique individual setups that cannot be covered in this document. As well, even very similar builds and configurations can behave very differently due to external factors, so your results may vary.
+There are a virtually unlimited number of unique individual setups that cannot be covered in this document. As well, even similar builds and configurations can behave differently due to external factors, so your results may vary.
 
 Here are some general guidelines to use as a starting point. Be cautious, make incremental changes, testing and observing before moving forward.
 Always focus on only one specific area at a time - avoid making changes to memory, storage, and CPU configs all at once. Diagnosing potential problems becomes nearly impossible otherwise.

--- a/node/node-operators.mdx
+++ b/node/node-operators.mdx
@@ -63,7 +63,8 @@ timeout-broadcast-tx-commit = "10s"
 
 ```toml
 # Minimum gas prices to prevent spam transactions
-minimum-gas-prices = "0.01usei"
+# (mainnet enforces a chain-wide minimum of 0.02usei)
+minimum-gas-prices = "0.02usei"
 
 # Block retention for /block, /block_results, etc., and the floor used by
 # the receipt store's pruner. 0 disables block pruning.
@@ -1520,19 +1521,20 @@ may be required:
 # Check database size
 du -sh $HOME/.sei/data/
 
-# Confirm correct file paths as per your own setup before proceeding
-# Before performing a database wipe, ensure you back up essential files:
+# Confirm correct file paths as per your own setup before proceeding.
+# Back up the data directory BEFORE wiping it:
+cp -r $HOME/.sei/data/ $HOME/sei-backup-$(date +%Y%m%d)/
+
+# Your keys and config live in $HOME/.sei/config and are NOT removed by the
+# wipe below, but keep them safe regardless:
 # - `node_key.json`: Preserves node identity to maintain peer connections.
 # - `priv_validator_key.json`: Critical for validators; losing this key results in double signing risks.
 # - `config.toml` & `app.toml`: Retains node-specific configuration.
 # - `genesis.json`: Required for correct chain initialization.
 
-# Wipe database for a fresh resync (destructive — deletes all chain data)
+# Wipe database for a fresh resync (destructive — deletes all chain data
+# except priv_validator_state.json)
 find $HOME/.sei/data/ -mindepth 1 ! -name 'priv_validator_state.json' -delete && rm -rf $HOME/.sei/wasm
-
-
-# Backup database
-cp -r $HOME/.sei/data/ $HOME/sei-backup-$(date +%Y%m%d)/
 ```
 
 <Warning>The wipe command above deletes the entire local database (everything except `priv_validator_state.json`) and the `wasm` folder. It does not compact data in place — after running it, the node must be re-synced from a [snapshot](/node/snapshot) or via [state sync](/node/statesync) before it can serve traffic again.</Warning>

--- a/node/node-operators.mdx
+++ b/node/node-operators.mdx
@@ -1464,7 +1464,7 @@ async-write-buffer = 100
 prune-interval-seconds = 600
 ```
 
-Setting very small (more frequent) pruning intervals may collide with
+Setting small (more frequent) pruning intervals may collide with
 snapshot creation. Too-large (less frequent) intervals mean pruning takes
 longer overall, which can cause missed blocks and excessive resync time.
 

--- a/node/rocksdb-backend.mdx
+++ b/node/rocksdb-backend.mdx
@@ -98,7 +98,7 @@ ss-backend = "rocksdb"
 ## TL;DR
 
 - RocksDB backend drastically improves trace iteration and historical query performance.
-- Install once, then simply run:
+- Install once, then run:
 
 ```bash
 make install-rocksdb

--- a/node/seictl.mdx
+++ b/node/seictl.mdx
@@ -226,7 +226,7 @@ seictl config patch patch.toml
 seictl config --target app patch patch.toml
 
 # Patch from stdin and output to stdout
-echo 'minimum-gas-prices = "0.01usei"' | seictl config patch
+echo 'minimum-gas-prices = "0.02usei"' | seictl config patch
 
 # Patch and modify in-place
 seictl config --target app patch patch.toml -i
@@ -339,7 +339,7 @@ echo '{"chain_id": "pacific-1"}' | seictl genesis patch -i
 <Accordion title="Update Multiple Configuration Sections">
 ```bash
 cat > patch.toml << EOF
-minimum-gas-prices = "0.01usei"
+minimum-gas-prices = "0.02usei"
 
 [telemetry]
 enabled = true

--- a/node/technical-reference.mdx
+++ b/node/technical-reference.mdx
@@ -92,7 +92,7 @@ The app.toml file controls application-specific settings:
 <Accordion title="Complete app.toml Configuration">
 ```toml
 # Minimum gas prices for transaction acceptance
-minimum-gas-prices = "0.01usei"
+minimum-gas-prices = "0.02usei"
 
 # API configuration
 [api]

--- a/node/validators.mdx
+++ b/node/validators.mdx
@@ -88,7 +88,7 @@ seid tx staking create-validator \
     --min-self-delegation="1" \
     --gas="auto" \
     --gas-adjustment="1.5" \
-    --gas-prices="0.01usei" \
+    --gas-prices="0.02usei" \
     --from=operator
 ```
 
@@ -207,7 +207,7 @@ seid tx gov vote 1 yes \
     --from operator \
     --chain-id pacific-1 \
     --gas auto \
-    --gas-prices 0.01usei
+    --gas-prices 0.02usei
 ```
 
 ## Recovery Procedures

--- a/node/validators.mdx
+++ b/node/validators.mdx
@@ -225,7 +225,7 @@ Never run your validator keys on more than one machine simultaneously. If your p
 The safe approach to recovery is:
 
 1. Diagnose why the original validator is offline
-2. If the original validator cannot be recovered, verify it is completely offline and powered down
+2. If the original validator cannot be recovered, verify it is offline and powered down
 3. Only then proceed with key migration to a new machine
 
 ### Validator Recovery


### PR DESCRIPTION
## What is the purpose of the change?

Corrects existing documentation. This is a follow-up to the now-merged review in #27 — it resolves a few issues the review surfaced but #27 didn't fully address, and clears the actionable Vale prose-lint findings.

## Describe the changes to the documentation

**Correctness fixes** (`89629a8`):
- **Gas price:** propagate the `0.02usei` chain-wide minimum (per the Cosmos chain registry's `fixed_min_gas_price` and #27's own note) to the node guides and validator tx examples that still showed `0.01usei` — `node-operators`, `validators` (create-validator + gov vote), `seictl`, `technical-reference`. The auto-generated `seid init` default block is intentionally left untouched.
- **ethers v6:** `receipt.transactionHash` → `receipt.hash` (4 sites in the bank precompile guide), and rename the mislabeled `amountInUsei` (it parses 18-decimal wei) to `amountInWei`.
- **node-operators DB maintenance:** reorder the block so the backup runs *before* the destructive wipe — previously the `cp` ran after the wipe, copying an empty data dir.
- **Imports:** `learn/accounts.mdx` now imports precompile constants from `@sei-js/precompiles` (matching every other precompile page) instead of `@sei-js/evm`.
- **Hardhat:** `evm-hardhat.mdx` uses `network.create()` (the official Hardhat 3 API) instead of `network.getOrCreate()`.

**Vale prose cleanup** (`eeb292a`):
- Terminology: "gas fees" → "gas" across 17 pages (22 hits); "Metamask" → "MetaMask".
- Qualifiers: drop filler (`really`/`simply`/`completely`/`essentially`/`very`) at 19 sites.
- `Sei.Terminology` rule: remove the noisy bare-`CW` → `CosmWasm` swap. It only fired on legitimate shorthand ("CW pointer", "CW-based", "CW NFT", "CW standards") — `CW20`/`CW721`/`CW1155` were never matched (the trailing digit blocks the word boundary). CosmWasm casing stays enforced by the `[Cc]osmwasm` rule.

## Notes

- **Verified:** `vale` now reports only the pre-existing sentence-case heading backlog (`Sei.Headings`), left untouched per the CI's advisory, changed-lines-only policy; `typos` reports 0.
- In-code occurrences of "gas fees" (`console.log`/`throw`) and the `dev-gas` SEO keyword are intentionally preserved.
- Rebased onto current `main` (clean — no overlap with the `llms.txt` regeneration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
