### PR TITLE
feat: runnable code & sandbox embeds across the EVM docs

### DIFF
--- a/evm/debugging-contracts.mdx
+++ b/evm/debugging-contracts.mdx
@@ -3,6 +3,9 @@ title: 'Debugging for EVM'
 description: 'Advanced debugging techniques for EVM transactions on Sei. Learn transaction template generation and analysis using seid and Foundry cast tools.'
 keywords: ['EVM debugging', 'transaction templates', 'foundry cast', 'evm analysis', 'transaction debugging']
 ---
+
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+
 ## Overview
 
 Debugging EVM transactions on Sei requires understanding both the transaction creation process and how to analyze transaction behavior. This guide covers advanced debugging techniques using transaction template generation, analysis tools, and comprehensive transaction inspection methods to help developers identify and resolve issues in their EVM interactions.
@@ -164,6 +167,30 @@ cast chain-id --rpc-url=$EVM_RPC_URL
 - Insufficient native balance for gas
 - Underpriced `maxFeePerGas`/`maxPriorityFeePerGas`
 - Chain ID mismatch
+
+### Try it live
+
+Each `cast` diagnostic above is a plain read-only JSON-RPC call. Run the same four against Sei mainnet right here — the example address (`0xAa55…3d96`) is the sender from the `cast tx` output earlier on this page.
+
+<RunSnippet method="eth_chainId" network="mainnet" title="cast chain-id" description="eth_chainId — decodes to 1329. A mismatch here is the most common cause of a rejected transaction." />
+
+<RunSnippet method="eth_gasPrice" network="mainnet" title="cast gas-price" description="eth_gasPrice — the current gas price in wei. Compare it against your maxFeePerGas when a transaction is stuck as underpriced." />
+
+<RunSnippet
+  method="eth_getTransactionCount"
+  params={['0xAa55a16dD4E73c48C968928983c2bcC98d913d96', 'latest']}
+  network="mainnet"
+  title="cast nonce 0xAa55…3d96"
+  description="eth_getTransactionCount at the latest block — the account's next nonce. Swap in your own address."
+/>
+
+<RunSnippet
+  method="eth_getBalance"
+  params={['0xAa55a16dD4E73c48C968928983c2bcC98d913d96', 'latest']}
+  network="mainnet"
+  title="cast balance 0xAa55…3d96"
+  description="eth_getBalance in wei — confirm the account can cover gas before you dig into a failed send."
+/>
 
 ---
 

--- a/evm/debugging-contracts.mdx
+++ b/evm/debugging-contracts.mdx
@@ -168,7 +168,7 @@ cast chain-id --rpc-url=$EVM_RPC_URL
 - Underpriced `maxFeePerGas`/`maxPriorityFeePerGas`
 - Chain ID mismatch
 
-### Try it live
+## Try it live
 
 Each `cast` diagnostic above is a plain read-only JSON-RPC call. Run the same four against Sei mainnet right here — the example address (`0xAa55…3d96`) is the sender from the `cast tx` output earlier on this page.
 

--- a/evm/evm-foundry.mdx
+++ b/evm/evm-foundry.mdx
@@ -4,6 +4,11 @@ sidebarTitle: 'EVM with Foundry'
 description: 'Learn how to develop, test, and deploy smart contracts on Sei EVM using Foundry, with step-by-step examples of contract creation, testing, deployment, and interaction using both CLI and ethers.js.'
 keywords: ['sei evm', 'foundry', 'forge', 'smart contract', 'web3 development', 'nft', 'erc721', 'erc20']
 ---
+
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+import { AddSeiButton } from '/snippets/add-sei-button.jsx';
+
 This tutorial will guide you through setting up Foundry for Sei EVM development and using OpenZeppelin contracts to build secure, standardized smart contracts. We'll cover environment setup, contract creation, deployment, and show how to leverage OpenZeppelin's pre-built components with the powerful Foundry toolkit.
 
 <Info>Watch the video walkthrough for this topic in the [Video Tutorials](/evm/videos) section.</Info>
@@ -15,6 +20,27 @@ This tutorial will guide you through setting up Foundry for Sei EVM development 
 It is <strong>highly recommended</strong> that you deploy to <em>testnet (atlantic-2)</em> first and verify everything works as expected before committing to mainnet. Doing so helps you catch bugs early, avoid unnecessary gas costs, and keep your users safe.
 
 </Tip>
+
+## Try it before you install
+
+Installing Foundry and scaffolding a project takes a few minutes. If you just want to see a contract deploy to Sei, you can do both of these right now in the browser.
+
+First, confirm the RPC endpoints you'll put in `foundry.toml` respond:
+
+<RunSnippet method="eth_chainId" network="testnet" title="eth_chainId · atlantic-2" description="Testnet RPC — decodes to 1328." />
+
+<RunSnippet method="eth_chainId" network="mainnet" title="eth_chainId · pacific-1" description="Mainnet RPC — decodes to 1329." />
+
+Then add Sei testnet to your wallet and deploy a minimal `Counter.sol` from Remix — no `forge`, no install. In Remix: compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask**.
+
+<AddSeiButton network="testnet" label="Add Sei testnet" />
+
+<SandboxEmbed
+  kind="remix"
+  src="https://remix.ethereum.org/?#activate=solidity,fileManager&code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC4yNDsKCi8vLyBAdGl0bGUgQ291bnRlciDigJQgbWluaW1hbCBjb250cmFjdCB0byBjb21waWxlICYgZGVwbG95IHRvIFNlaSB0ZXN0bmV0Lgpjb250cmFjdCBDb3VudGVyIHsKICAgIHVpbnQyNTYgcHVibGljIGNvdW50OwogICAgZnVuY3Rpb24gaW5jcmVtZW50KCkgZXh0ZXJuYWwgeyBjb3VudCsrOyB9CiAgICBmdW5jdGlvbiBkZWNyZW1lbnQoKSBleHRlcm5hbCB7IGNvdW50LS07IH0KfQ"
+  title="Counter.sol · deploy to Sei testnet"
+  description="Remix IDE with a minimal Counter contract preloaded. Compile in-browser, then deploy to Sei testnet."
+/>
 
 ## Table of Contents
 

--- a/evm/evm-foundry.mdx
+++ b/evm/evm-foundry.mdx
@@ -44,6 +44,7 @@ Then add Sei testnet to your wallet and deploy a minimal `Counter.sol` from Remi
 
 ## Table of Contents
 
+- [Try it before you install](#try-it-before-you-install)
 - [Prerequisites](#prerequisites)
 - [Setting Up Your Development Environment](#setting-up-your-development-environment)
 - [Configuring Foundry for Sei EVM](#configuring-foundry-for-sei-evm)

--- a/evm/evm-general.mdx
+++ b/evm/evm-general.mdx
@@ -4,6 +4,11 @@ sidebarTitle: 'EVM (General)'
 description: "Comprehensive guide on Ethereum Virtual Machine (EVM) on Sei blockchain. Learn about smart contract languages, development tools, and best practices for building on Sei's parallelized EVM."
 keywords: ['sei evm', 'ethereum virtual machine', 'smart contracts', 'solidity', 'vyper']
 ---
+
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+import { AddSeiButton } from '/snippets/add-sei-button.jsx';
+
 ## Overview
 
 The Ethereum Virtual Machine (EVM) is the runtime environment for smart
@@ -25,6 +30,25 @@ Here are some key points about the EVM:
 3. **Bytecode Execution**: Smart contracts are compiled into bytecode (low-level
    machine-readable instructions) and deployed to the EVM compatible network.
    The EVM executes this bytecode.
+
+## Try it: deploy without any setup
+
+You don't need a local toolchain to ship a contract to Sei. First confirm the network is live, then compile and deploy a minimal `Counter.sol` to testnet straight from the browser.
+
+<RunSnippet method="eth_chainId" network="testnet" title="eth_chainId · atlantic-2" description="Confirms the testnet RPC responds — decodes to 1328, the chain ID your tooling needs." />
+
+<RunSnippet method="eth_chainId" network="mainnet" title="eth_chainId · pacific-1" description="Confirms the mainnet RPC responds — decodes to 1329." />
+
+Add Sei testnet to your wallet, then deploy from Remix below — compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask**:
+
+<AddSeiButton network="testnet" label="Add Sei testnet" />
+
+<SandboxEmbed
+  kind="remix"
+  src="https://remix.ethereum.org/?#activate=solidity,fileManager&code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC4yNDsKCi8vLyBAdGl0bGUgQ291bnRlciDigJQgbWluaW1hbCBjb250cmFjdCB0byBjb21waWxlICYgZGVwbG95IHRvIFNlaSB0ZXN0bmV0Lgpjb250cmFjdCBDb3VudGVyIHsKICAgIHVpbnQyNTYgcHVibGljIGNvdW50OwogICAgZnVuY3Rpb24gaW5jcmVtZW50KCkgZXh0ZXJuYWwgeyBjb3VudCsrOyB9CiAgICBmdW5jdGlvbiBkZWNyZW1lbnQoKSBleHRlcm5hbCB7IGNvdW50LS07IH0KfQ"
+  title="Counter.sol · deploy to Sei testnet"
+  description="Remix IDE with a minimal Counter contract preloaded. Compile in-browser, then deploy to Sei testnet."
+/>
 
 ## Smart contract languages
 

--- a/evm/evm-hardhat.mdx
+++ b/evm/evm-hardhat.mdx
@@ -44,6 +44,7 @@ Then add Sei testnet to your wallet and deploy a minimal `Counter.sol` from Remi
 
 ## Table of Contents
 
+- [Try it before you install](#try-it-before-you-install)
 - [Prerequisites](#prerequisites)
 - [Setting Up Your Development Environment](#setting-up-your-development-environment)
 - [Configuring Hardhat for Sei EVM](#configuring-hardhat-for-sei-evm)

--- a/evm/evm-hardhat.mdx
+++ b/evm/evm-hardhat.mdx
@@ -4,6 +4,11 @@ sidebarTitle: 'EVM with Hardhat'
 description: 'Learn how to set up Hardhat for Sei EVM development, create and deploy smart contracts, and leverage OpenZeppelin components for secure, standardized implementations.'
 keywords: ['hardhat', 'smart contracts', 'sei development', 'evm deployment', 'openzeppelin']
 ---
+
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+import { AddSeiButton } from '/snippets/add-sei-button.jsx';
+
 This tutorial will guide you through setting up Hardhat for Sei EVM development and using OpenZeppelin contracts to build secure, standardized smart contracts. We'll cover environment setup, contract creation, deployment, and show how to leverage OpenZeppelin's pre-built components.
 
 <Info>Watch the video walkthrough for this topic in the [Video Tutorials](/evm/videos) section.</Info>
@@ -15,6 +20,27 @@ This tutorial will guide you through setting up Hardhat for Sei EVM development 
 It is <strong>highly recommended</strong> that you deploy to <em>testnet (atlantic-2)</em> first and verify everything works as expected before committing to mainnet. Doing so helps you catch bugs early, avoid unnecessary gas costs, and keep your users safe.
 
 </Tip>
+
+## Try it before you install
+
+Setting up the full toolchain takes a few minutes. If you just want to see a contract deploy to Sei, you can do both of these right now in the browser.
+
+First, confirm the RPC endpoints you'll put in `hardhat.config` respond:
+
+<RunSnippet method="eth_chainId" network="testnet" title="eth_chainId · atlantic-2" description="Testnet RPC — decodes to 1328." />
+
+<RunSnippet method="eth_chainId" network="mainnet" title="eth_chainId · pacific-1" description="Mainnet RPC — decodes to 1329." />
+
+Then add Sei testnet to your wallet and deploy a minimal `Counter.sol` from Remix — no Node, no install. In Remix: compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask**.
+
+<AddSeiButton network="testnet" label="Add Sei testnet" />
+
+<SandboxEmbed
+  kind="remix"
+  src="https://remix.ethereum.org/?#activate=solidity,fileManager&code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC4yNDsKCi8vLyBAdGl0bGUgQ291bnRlciDigJQgbWluaW1hbCBjb250cmFjdCB0byBjb21waWxlICYgZGVwbG95IHRvIFNlaSB0ZXN0bmV0Lgpjb250cmFjdCBDb3VudGVyIHsKICAgIHVpbnQyNTYgcHVibGljIGNvdW50OwogICAgZnVuY3Rpb24gaW5jcmVtZW50KCkgZXh0ZXJuYWwgeyBjb3VudCsrOyB9CiAgICBmdW5jdGlvbiBkZWNyZW1lbnQoKSBleHRlcm5hbCB7IGNvdW50LS07IH0KfQ"
+  title="Counter.sol · deploy to Sei testnet"
+  description="Remix IDE with a minimal Counter contract preloaded. Compile in-browser, then deploy to Sei testnet."
+/>
 
 ## Table of Contents
 

--- a/evm/evm-parity/examples/deploy-verify.mdx
+++ b/evm/evm-parity/examples/deploy-verify.mdx
@@ -10,7 +10,7 @@ Sei is EVM-compatible — standard deployment tooling works without modification
 
 For a deeper look at verification options (Remix, Sourcify UI, batch verification), see the [Verify Contracts](/evm/evm-verify-contracts) page.
 
-## Deploy from your browser (Remix)
+## Try it: deploy from your browser
 
 No local toolchain required — compile and deploy a contract to Sei testnet straight from the browser. The Remix sandbox below preloads a minimal `Counter.sol`.
 
@@ -18,7 +18,7 @@ First, add Sei testnet to your wallet:
 
 <AddSeiButton network="testnet" label="Add Sei testnet" />
 
-Then in Remix: compile under the **Solidity Compiler** tab, open **Deploy & Run**, set **Environment** to **Injected Provider — MetaMask** (or **External HTTP Provider** pointed at `https://evm-rpc-testnet.sei-apis.com`), and click **Deploy**. Sei has instant finality, so the deployment confirms in well under a second.
+Then in Remix: compile under the **Solidity Compiler** tab, open **Deploy & Run**, set **Environment** to **Injected Provider — MetaMask**, and click **Deploy**. Sei has instant finality, so the deployment confirms in well under a second.
 
 <SandboxEmbed
   kind="remix"

--- a/evm/evm-parity/examples/deploy-verify.mdx
+++ b/evm/evm-parity/examples/deploy-verify.mdx
@@ -3,9 +3,29 @@ title: 'Deploy and Verify'
 description: 'Deploying and verifying smart contracts on Sei with viem, ethers, Foundry, and Hardhat'
 ---
 
+import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+import { AddSeiButton } from '/snippets/add-sei-button.jsx';
+
 Sei is EVM-compatible — standard deployment tooling works without modification. This page covers deploying a contract and verifying its source on the Sei block explorer.
 
 For a deeper look at verification options (Remix, Sourcify UI, batch verification), see the [Verify Contracts](/evm/evm-verify-contracts) page.
+
+## Deploy from your browser (Remix)
+
+No local toolchain required — compile and deploy a contract to Sei testnet straight from the browser. The Remix sandbox below preloads a minimal `Counter.sol`.
+
+First, add Sei testnet to your wallet:
+
+<AddSeiButton network="testnet" label="Add Sei testnet" />
+
+Then in Remix: compile under the **Solidity Compiler** tab, open **Deploy & Run**, set **Environment** to **Injected Provider — MetaMask** (or **External HTTP Provider** pointed at `https://evm-rpc-testnet.sei-apis.com`), and click **Deploy**. Sei has instant finality, so the deployment confirms in well under a second.
+
+<SandboxEmbed
+  kind="remix"
+  src="https://remix.ethereum.org/?#activate=solidity,fileManager&code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC4yNDsKCi8vLyBAdGl0bGUgQ291bnRlciDigJQgbWluaW1hbCBjb250cmFjdCB0byBjb21waWxlICYgZGVwbG95IHRvIFNlaSB0ZXN0bmV0Lgpjb250cmFjdCBDb3VudGVyIHsKICAgIHVpbnQyNTYgcHVibGljIGNvdW50OwogICAgZnVuY3Rpb24gaW5jcmVtZW50KCkgZXh0ZXJuYWwgeyBjb3VudCsrOyB9CiAgICBmdW5jdGlvbiBkZWNyZW1lbnQoKSBleHRlcm5hbCB7IGNvdW50LS07IH0KfQ"
+  title="Counter.sol · deploy to Sei testnet"
+  description="Remix IDE with a minimal Counter contract preloaded. Compile in-browser, then deploy to Sei testnet."
+/>
 
 ## Deploying with viem or ethers
 

--- a/evm/evm-parity/examples/erc1155.mdx
+++ b/evm/evm-parity/examples/erc1155.mdx
@@ -3,9 +3,29 @@ title: 'ERC-1155 Interaction'
 description: 'Reading and writing ERC-1155 multi-token contracts on Sei with viem and ethers'
 ---
 
+import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+import { AddSeiButton } from '/snippets/add-sei-button.jsx';
+
 # ERC-1155 Interaction
 
 ERC-1155 is the multi-token standard — a single contract can hold both fungible tokens (like gold coins in a game) and non-fungible tokens (like unique items), with efficient batch operations built in. Standard ERC-1155 contracts work on Sei without modification.
+
+## Try it: deploy an ERC-1155
+
+Compile and deploy a real ERC-1155 to Sei testnet from the browser — the Remix sandbox preloads an OpenZeppelin-based `DemoMultiToken` with a public `mint(id, amount)`. Then point the read/write patterns below at your deployed address.
+
+First, add Sei testnet to your wallet:
+
+<AddSeiButton network="testnet" label="Add Sei testnet" />
+
+In Remix, compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask** (or **External HTTP Provider** at `https://evm-rpc-testnet.sei-apis.com`).
+
+<SandboxEmbed
+  kind="remix"
+  src="https://remix.ethereum.org/?#activate=solidity,fileManager&code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC4yNDsKCmltcG9ydCAiQG9wZW56ZXBwZWxpbi9jb250cmFjdHMvdG9rZW4vRVJDMTE1NS9FUkMxMTU1LnNvbCI7Cgpjb250cmFjdCBEZW1vTXVsdGlUb2tlbiBpcyBFUkMxMTU1IHsKICAgIHVpbnQyNTYgcHVibGljIGNvbnN0YW50IEdPTEQgPSAwOwogICAgdWludDI1NiBwdWJsaWMgY29uc3RhbnQgU0lMVkVSID0gMTsKICAgIGNvbnN0cnVjdG9yKCkgRVJDMTE1NSgiaHR0cHM6Ly9leGFtcGxlLmNvbS9hcGkvaXRlbS97aWR9Lmpzb24iKSB7fQogICAgZnVuY3Rpb24gbWludCh1aW50MjU2IGlkLCB1aW50MjU2IGFtb3VudCkgZXh0ZXJuYWwgeyBfbWludChtc2cuc2VuZGVyLCBpZCwgYW1vdW50LCAiIik7IH0KfQo"
+  title="DemoMultiToken (ERC-1155) · deploy to Sei testnet"
+  description="Remix IDE with an OpenZeppelin ERC-1155 preloaded. Compile in-browser and deploy to Sei testnet."
+/>
 
 ## Setup
 

--- a/evm/evm-parity/examples/erc1155.mdx
+++ b/evm/evm-parity/examples/erc1155.mdx
@@ -18,7 +18,7 @@ First, add Sei testnet to your wallet:
 
 <AddSeiButton network="testnet" label="Add Sei testnet" />
 
-In Remix, compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask** (or **External HTTP Provider** at `https://evm-rpc-testnet.sei-apis.com`).
+In Remix, compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask**.
 
 <SandboxEmbed
   kind="remix"

--- a/evm/evm-parity/examples/erc20.mdx
+++ b/evm/evm-parity/examples/erc20.mdx
@@ -3,9 +3,29 @@ title: 'ERC-20 Interaction'
 description: 'Reading and writing ERC-20 tokens on Sei with viem and ethers'
 ---
 
+import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+import { AddSeiButton } from '/snippets/add-sei-button.jsx';
+
 # ERC-20 Interaction
 
 Standard ERC-20 contracts work on Sei without modification. This page covers the common read and write operations using viem and ethers.
+
+## Try it: deploy an ERC-20
+
+Compile and deploy a real ERC-20 to Sei testnet from the browser — the Remix sandbox preloads an OpenZeppelin-based `DemoToken`. Then point the read/write patterns below at your deployed address.
+
+First, add Sei testnet to your wallet:
+
+<AddSeiButton network="testnet" label="Add Sei testnet" />
+
+In Remix, compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask** (or **External HTTP Provider** at `https://evm-rpc-testnet.sei-apis.com`).
+
+<SandboxEmbed
+  kind="remix"
+  src="https://remix.ethereum.org/?#activate=solidity,fileManager&code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC4yNDsKCmltcG9ydCAiQG9wZW56ZXBwZWxpbi9jb250cmFjdHMvdG9rZW4vRVJDMjAvRVJDMjAuc29sIjsKCmNvbnRyYWN0IERlbW9Ub2tlbiBpcyBFUkMyMCB7CiAgICBjb25zdHJ1Y3RvcigpIEVSQzIwKCJEZW1vIFRva2VuIiwgIkRFTU8iKSB7CiAgICAgICAgX21pbnQobXNnLnNlbmRlciwgMV8wMDBfMDAwICogMTAgKiogZGVjaW1hbHMoKSk7CiAgICB9Cn0"
+  title="DemoToken (ERC-20) · deploy to Sei testnet"
+  description="Remix IDE with an OpenZeppelin ERC-20 preloaded. Compile in-browser and deploy to Sei testnet."
+/>
 
 ## Setup
 

--- a/evm/evm-parity/examples/erc20.mdx
+++ b/evm/evm-parity/examples/erc20.mdx
@@ -18,7 +18,7 @@ First, add Sei testnet to your wallet:
 
 <AddSeiButton network="testnet" label="Add Sei testnet" />
 
-In Remix, compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask** (or **External HTTP Provider** at `https://evm-rpc-testnet.sei-apis.com`).
+In Remix, compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask**.
 
 <SandboxEmbed
   kind="remix"

--- a/evm/evm-parity/examples/erc721.mdx
+++ b/evm/evm-parity/examples/erc721.mdx
@@ -3,9 +3,29 @@ title: 'ERC-721 Interaction'
 description: 'Reading and writing ERC-721 NFTs on Sei with viem and ethers'
 ---
 
+import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+import { AddSeiButton } from '/snippets/add-sei-button.jsx';
+
 # ERC-721 Interaction
 
 Standard ERC-721 contracts work on Sei without modification. This page covers reading token ownership, transferring NFTs, and managing approvals.
+
+## Try it: deploy an ERC-721
+
+Compile and deploy a real ERC-721 to Sei testnet from the browser — the Remix sandbox preloads an OpenZeppelin-based `DemoNFT` with a public `mint()`. Then point the patterns below at your deployed address.
+
+First, add Sei testnet to your wallet:
+
+<AddSeiButton network="testnet" label="Add Sei testnet" />
+
+In Remix, compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask** (or **External HTTP Provider** at `https://evm-rpc-testnet.sei-apis.com`).
+
+<SandboxEmbed
+  kind="remix"
+  src="https://remix.ethereum.org/?#activate=solidity,fileManager&code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC4yNDsKCmltcG9ydCAiQG9wZW56ZXBwZWxpbi9jb250cmFjdHMvdG9rZW4vRVJDNzIxL0VSQzcyMS5zb2wiOwoKY29udHJhY3QgRGVtb05GVCBpcyBFUkM3MjEgewogICAgdWludDI1NiBwdWJsaWMgbmV4dElkOwogICAgY29uc3RydWN0b3IoKSBFUkM3MjEoIkRlbW8gTkZUIiwgIkRORlQiKSB7fQogICAgZnVuY3Rpb24gbWludCgpIGV4dGVybmFsIHsgX3NhZmVNaW50KG1zZy5zZW5kZXIsIG5leHRJZCsrKTsgfQp9"
+  title="DemoNFT (ERC-721) · deploy to Sei testnet"
+  description="Remix IDE with an OpenZeppelin ERC-721 preloaded. Compile in-browser and deploy to Sei testnet."
+/>
 
 ## Setup
 

--- a/evm/evm-parity/examples/erc721.mdx
+++ b/evm/evm-parity/examples/erc721.mdx
@@ -18,7 +18,7 @@ First, add Sei testnet to your wallet:
 
 <AddSeiButton network="testnet" label="Add Sei testnet" />
 
-In Remix, compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask** (or **External HTTP Provider** at `https://evm-rpc-testnet.sei-apis.com`).
+In Remix, compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask**.
 
 <SandboxEmbed
   kind="remix"

--- a/evm/evm-parity/examples/error-handling.mdx
+++ b/evm/evm-parity/examples/error-handling.mdx
@@ -3,9 +3,31 @@ title: 'Error Handling'
 description: 'Decode contract reverts, handle wallet rejections, and recover from RPC errors in Sei apps'
 ---
 
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+
 # Error Handling
 
 Most transaction failures fall into three categories: contract reverts, wallet rejections, and RPC errors. This page shows how to decode each type and respond correctly.
+
+## Try it: see real errors
+
+The `RunSnippet` widget surfaces whatever the RPC returns — including failures. These two calls fail on purpose so you can see the exact error shape your code has to handle, live against Sei mainnet.
+
+<RunSnippet
+  method="eth_call"
+  params={[{ to: '0xcA11bde05977b3631167028862bE2a173976CA11', data: '0xdeadbeef' }, 'latest']}
+  network="mainnet"
+  title="A contract revert"
+  description="Calls an unknown selector (0xdeadbeef) on Multicall3. The node rejects it with execution reverted — the same class of failure as the Contract Reverts section below."
+/>
+
+<RunSnippet
+  method="eth_getBalance"
+  params={['0x123', 'latest']}
+  network="mainnet"
+  title="An RPC argument error"
+  description="A malformed address (0x123) triggers a JSON-RPC -32602 invalid argument error — distinct from a revert, and the kind of failure the RPC Errors and Retries section below handles."
+/>
 
 ## Contract Reverts
 

--- a/evm/evm-parity/examples/ethers-quickstart.mdx
+++ b/evm/evm-parity/examples/ethers-quickstart.mdx
@@ -3,6 +3,9 @@ title: 'ethers v6 Quickstart'
 description: 'Using ethers v6 with Sei in a Node.js script or browser context'
 ---
 
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+
 # ethers v6 Quickstart
 
 This example covers ethers v6 with Sei. The patterns apply whether you are writing a Node.js script, a CLI tool, or a browser app.
@@ -54,6 +57,31 @@ Nonce: 7
 ```
 
 The exact numbers are illustrative — your block number and balance will differ. `getBlockNumber()` and `getTransactionCount()` return a `number`, while `getBalance()` returns a `bigint` in wei (format it with `ethers.formatEther()`).
+
+## Try It Live
+
+Run these read-only calls against Sei mainnet right now — no install, no private key. They're plain JSON-RPC, the same reads the script above performs.
+
+<RunSnippet method="eth_blockNumber" network="mainnet" title="eth_blockNumber" />
+
+<RunSnippet
+  method="eth_getBalance"
+  params={["0x0000000000000000000000000000000000000000", "latest"]}
+  network="mainnet"
+  title="eth_getBalance"
+  description="Balance in wei of the example address at the latest block — swap in any address."
+/>
+
+## Edit and run
+
+Edit and re-run the full ethers code from this page live in the browser — a real ethers v6 `JsonRpcProvider` reading Sei testnet:
+
+<SandboxEmbed
+  kind="codesandbox"
+  src="https://codesandbox.io/embed/qs82lw?view=split&hidenavigation=1&theme=dark"
+  title="ethers · read Sei testnet"
+  description="A real ethers v6 provider reading Sei testnet (atlantic-2). Edit index.js and the preview re-runs."
+/>
 
 ## Browser Provider
 

--- a/evm/evm-parity/examples/ethers-quickstart.mdx
+++ b/evm/evm-parity/examples/ethers-quickstart.mdx
@@ -58,7 +58,7 @@ Nonce: 7
 
 The exact numbers are illustrative — your block number and balance will differ. `getBlockNumber()` and `getTransactionCount()` return a `number`, while `getBalance()` returns a `bigint` in wei (format it with `ethers.formatEther()`).
 
-## Try It Live
+## Try it live
 
 Run these read-only calls against Sei mainnet right now — no install, no private key. They're plain JSON-RPC, the same reads the script above performs.
 
@@ -74,7 +74,7 @@ Run these read-only calls against Sei mainnet right now — no install, no priva
 
 ## Edit and run
 
-Edit and re-run the full ethers code from this page live in the browser — a real ethers v6 `JsonRpcProvider` reading Sei testnet:
+Edit and re-run the full ethers code from this page live in the browser — a real ethers v6 `JsonRpcProvider` reading Sei **testnet** (atlantic-2), so its block number and balances won't match the mainnet reads above:
 
 <SandboxEmbed
   kind="codesandbox"

--- a/evm/evm-parity/examples/multicall.mdx
+++ b/evm/evm-parity/examples/multicall.mdx
@@ -3,11 +3,33 @@ title: 'Multicall'
 description: 'Batch multiple contract reads into a single RPC call using Multicall3 on Sei'
 ---
 
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+
 # Multicall
 
 Multicall3 lets you batch multiple read calls into a single RPC round-trip, dramatically reducing latency for dashboards, portfolio pages, and any view that needs data from multiple contracts at once.
 
 Multicall3 is deployed at `0xcA11bde05977b3631167028862bE2a173976CA11` on Sei mainnet and testnet — the same address as Ethereum.
+
+## Try It Live
+
+Multicall3 is a normal contract — you can hit it with a single `eth_call` and no SDK. These run its two zero-argument helpers on Sei mainnet; the hex results decode to decimal below each response.
+
+<RunSnippet
+  method="eth_call"
+  params={[{ to: '0xcA11bde05977b3631167028862bE2a173976CA11', data: '0x42cbb15c' }, 'latest']}
+  network="mainnet"
+  title="Multicall3.getBlockNumber()"
+  description="Selector 0x42cbb15c on Multicall3 at 0xcA11…CA11 — returns the current block number."
+/>
+
+<RunSnippet
+  method="eth_call"
+  params={[{ to: '0xcA11bde05977b3631167028862bE2a173976CA11', data: '0x0f28c97d' }, 'latest']}
+  network="mainnet"
+  title="Multicall3.getCurrentBlockTimestamp()"
+  description="Selector 0x0f28c97d — returns the latest block's Unix timestamp in seconds."
+/>
 
 ## Batching ERC-20 Reads with viem
 

--- a/evm/evm-parity/examples/multicall.mdx
+++ b/evm/evm-parity/examples/multicall.mdx
@@ -11,7 +11,7 @@ Multicall3 lets you batch multiple read calls into a single RPC round-trip, dram
 
 Multicall3 is deployed at `0xcA11bde05977b3631167028862bE2a173976CA11` on Sei mainnet and testnet — the same address as Ethereum.
 
-## Try It Live
+## Try it live
 
 Multicall3 is a normal contract — you can hit it with a single `eth_call` and no SDK. These run its two zero-argument helpers on Sei mainnet; the hex results decode to decimal below each response.
 

--- a/evm/evm-parity/examples/sei-precompiles.mdx
+++ b/evm/evm-parity/examples/sei-precompiles.mdx
@@ -16,7 +16,7 @@ Available precompiles include:
 - **JSON** — parse JSON payloads within contracts
 - **P256** — verify P-256 elliptic curve signatures
 
-## Try It Live
+## Try it live
 
 Precompiles are callable like any contract — even with a plain `eth_call` from the browser. This hits the **Bank** precompile at `0x0000000000000000000000000000000000001001` on Sei mainnet, calling `name("usei")`. The response is ABI-encoded; it contains the bytes `53 45 49` — ASCII for `SEI`.
 

--- a/evm/evm-parity/examples/sei-precompiles.mdx
+++ b/evm/evm-parity/examples/sei-precompiles.mdx
@@ -3,6 +3,8 @@ title: 'Sei Precompiles'
 description: 'Interact with native Sei chain features — staking, governance, native token balances, and more — from EVM applications'
 ---
 
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+
 Sei exposes native chain functionality through precompiled contracts at deterministic EVM addresses. You can call them from any EVM library (viem, ethers, wagmi) using the ABIs exported from `@sei-js/precompiles` — no special SDK required.
 
 Available precompiles include:
@@ -13,6 +15,19 @@ Available precompiles include:
 - **Governance** — vote on active proposals
 - **JSON** — parse JSON payloads within contracts
 - **P256** — verify P-256 elliptic curve signatures
+
+## Try It Live
+
+Precompiles are callable like any contract — even with a plain `eth_call` from the browser. This hits the **Bank** precompile at `0x0000000000000000000000000000000000001001` on Sei mainnet, calling `name("usei")`. The response is ABI-encoded; it contains the bytes `53 45 49` — ASCII for `SEI`.
+
+<RunSnippet
+  method="eth_call"
+  params={[{ to: '0x0000000000000000000000000000000000001001', data: '0x5b43bc99000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000047573656900000000000000000000000000000000000000000000000000000000' }, 'latest']}
+  network="mainnet"
+  decode="off"
+  title="Bank.name('usei')"
+  description="Raw eth_call to the Bank precompile. Decoding off because the result is an ABI-encoded string, not a numeric quantity."
+/>
 
 For installation instructions, code examples (viem and ethers), common patterns, and a full working Node.js script, see the precompiles reference:
 

--- a/evm/evm-parity/examples/transaction-lifecycle.mdx
+++ b/evm/evm-parity/examples/transaction-lifecycle.mdx
@@ -9,7 +9,7 @@ import { RunSnippet } from '/snippets/run-snippet.jsx';
 
 This page covers the full round-trip of a transaction: building and sending it, waiting for the receipt, and reading the event logs it emitted.
 
-## Try It Live
+## Try it live
 
 Before you send anything, read the live chain state your transaction will interact with — straight from your browser against Sei mainnet, no install or key required.
 

--- a/evm/evm-parity/examples/transaction-lifecycle.mdx
+++ b/evm/evm-parity/examples/transaction-lifecycle.mdx
@@ -3,9 +3,19 @@ title: 'Transaction Lifecycle'
 description: 'Send transactions, wait for receipts, and decode event logs on Sei'
 ---
 
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+
 # Transaction Lifecycle
 
 This page covers the full round-trip of a transaction: building and sending it, waiting for the receipt, and reading the event logs it emitted.
+
+## Try It Live
+
+Before you send anything, read the live chain state your transaction will interact with — straight from your browser against Sei mainnet, no install or key required.
+
+<RunSnippet method="eth_gasPrice" network="mainnet" title="eth_gasPrice" description="Current gas price in wei — the widget decodes the hex quantity to decimal below the response." />
+
+<RunSnippet method="eth_blockNumber" network="mainnet" title="eth_blockNumber" description="Latest committed block on pacific-1. Your transaction lands a block or two after whatever this returns." />
 
 ## Sending a Transaction
 

--- a/evm/evm-parity/examples/viem-quickstart.mdx
+++ b/evm/evm-parity/examples/viem-quickstart.mdx
@@ -75,7 +75,7 @@ Nonce: 7
 
 The exact numbers are illustrative — your block number and balance will differ. Note the trailing `n`: `getBlockNumber()` and `getBalance()` return `bigint`, while `getTransactionCount()` returns a `number`.
 
-## Try It Live
+## Try it live
 
 Run these read-only calls against Sei mainnet right now — no install, no private key. They're the same reads the script above performs, issued straight from your browser.
 
@@ -93,7 +93,7 @@ Run these read-only calls against Sei mainnet right now — no install, no priva
 
 ## Edit and run
 
-The buttons above issue raw JSON-RPC. To run the full viem code from this page — imports, a public client, several reads — edit and re-run it live in the sandbox below. No install, no wallet, no key:
+The buttons above issue raw JSON-RPC. To run the full viem code from this page — imports, a public client, several reads — edit and re-run it live in the sandbox below. No install, no wallet, no key. Note the sandbox reads **testnet** (atlantic-2), so its block number and balances won't match the mainnet reads above:
 
 <SandboxEmbed
   kind="codesandbox"

--- a/evm/evm-parity/examples/viem-quickstart.mdx
+++ b/evm/evm-parity/examples/viem-quickstart.mdx
@@ -3,6 +3,9 @@ title: 'viem Quickstart'
 description: 'Using viem with Sei in a Node.js script, CLI tool, or backend service'
 ---
 
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+
 # viem Quickstart
 
 This example shows how to use viem with Sei outside of a React context — in a Node.js script, CLI tool, or backend service. For React apps, see [wagmi](https://wagmi.sh) and the [frontend guide](/evm/building-a-frontend).
@@ -71,6 +74,33 @@ Nonce: 7
 ```
 
 The exact numbers are illustrative — your block number and balance will differ. Note the trailing `n`: `getBlockNumber()` and `getBalance()` return `bigint`, while `getTransactionCount()` returns a `number`.
+
+## Try It Live
+
+Run these read-only calls against Sei mainnet right now — no install, no private key. They're the same reads the script above performs, issued straight from your browser.
+
+<RunSnippet method="eth_blockNumber" network="mainnet" title="eth_blockNumber" description="Latest committed block on pacific-1. Returns a hex quantity — the widget decodes it to decimal below the response." />
+
+<RunSnippet method="eth_chainId" network="mainnet" title="eth_chainId" description="Sei mainnet EVM chain ID. 0x531 = 1329." />
+
+<RunSnippet
+  method="eth_getBalance"
+  params={["0x0000000000000000000000000000000000000000", "latest"]}
+  network="mainnet"
+  title="eth_getBalance"
+  description="Balance in wei of the example address at the latest block — swap in any address."
+/>
+
+## Edit and run
+
+The buttons above issue raw JSON-RPC. To run the full viem code from this page — imports, a public client, several reads — edit and re-run it live in the sandbox below. No install, no wallet, no key:
+
+<SandboxEmbed
+  kind="codesandbox"
+  src="https://codesandbox.io/embed/cgtx45?view=split&hidenavigation=1&theme=dark"
+  title="viem · read Sei testnet"
+  description="A real viem public client reading Sei testnet (atlantic-2). Edit index.js and the preview re-runs."
+/>
 
 ## Wallet Client
 

--- a/evm/evm-parity/examples/wagmi-react.mdx
+++ b/evm/evm-parity/examples/wagmi-react.mdx
@@ -3,11 +3,32 @@ title: 'Wagmi + React'
 description: 'Connect wallets, read chain state, and write transactions in a React app on Sei using Wagmi'
 ---
 
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+
 # Wagmi + React
 
 [Wagmi](https://wagmi.sh) is the standard React library for EVM wallet connections and contract interactions. This page covers the essential patterns for a Sei frontend: configuration, wallet connect/disconnect, reading balances, and writing to contracts.
 
 For Node.js scripts and backend services, see the [viem Quickstart](/evm/evm-parity/examples/viem-quickstart) instead.
+
+## Try It Live
+
+The hooks below — `useBlockNumber`, `useBalance` — are thin wrappers over JSON-RPC reads. Here are those same reads issued directly against Sei mainnet, no wallet connection required, so you can see the data your components will render.
+
+<RunSnippet
+  method="eth_blockNumber"
+  network="mainnet"
+  title="eth_blockNumber"
+  description="What useBlockNumber() resolves to — the latest committed block on pacific-1."
+/>
+
+<RunSnippet
+  method="eth_getBalance"
+  params={['0x0000000000000000000000000000000000000000', 'latest']}
+  network="mainnet"
+  title="eth_getBalance"
+  description="What useBalance({ address }) reads under the hood — wei balance at the latest block. Swap in any address."
+/>
 
 ## Install
 

--- a/evm/evm-parity/examples/wagmi-react.mdx
+++ b/evm/evm-parity/examples/wagmi-react.mdx
@@ -11,7 +11,7 @@ import { RunSnippet } from '/snippets/run-snippet.jsx';
 
 For Node.js scripts and backend services, see the [viem Quickstart](/evm/evm-parity/examples/viem-quickstart) instead.
 
-## Try It Live
+## Try it live
 
 The hooks below — `useBlockNumber`, `useBalance` — are thin wrappers over JSON-RPC reads. Here are those same reads issued directly against Sei mainnet, no wallet connection required, so you can see the data your components will render.
 

--- a/evm/evm-verify-contracts.mdx
+++ b/evm/evm-verify-contracts.mdx
@@ -3,6 +3,10 @@ title: 'Verify Contracts'
 description: 'Comprehensive guide on how to verify your EVM smart contracts on Sei'
 keywords: ['contract verification', 'sourcify', 'hardhat', 'foundry', 'smart contracts', 'solidity', 'sei']
 ---
+
+import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+import { AddSeiButton } from '/snippets/add-sei-button.jsx';
+
 Verify your deployed contract using flattened source code, JSON input, Sourcify and more. Verifying your deployed contract ensures transparency and trust by making the source code publicly available and verifiable.
 
 ## Benefits of Verification
@@ -154,6 +158,17 @@ You can also verify contracts directly through the [Sourcify web interface](http
 ## Remix Contract Verification Plugin
 
 Remix IDE offers an automated contract verification solution through its Contract Verification plugin, which integrates with both Sourcify and Etherscan verification services.
+
+Don't have a contract deployed yet? Spin up Remix with a sample `Counter.sol`, deploy it to Sei testnet, then follow the steps below to verify it.
+
+<AddSeiButton network="testnet" label="Add Sei testnet" />
+
+<SandboxEmbed
+  kind="remix"
+  src="https://remix.ethereum.org/?#activate=solidity,fileManager&code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC4yNDsKCi8vLyBAdGl0bGUgQ291bnRlciDigJQgbWluaW1hbCBjb250cmFjdCB0byBjb21waWxlICYgZGVwbG95IHRvIFNlaSB0ZXN0bmV0Lgpjb250cmFjdCBDb3VudGVyIHsKICAgIHVpbnQyNTYgcHVibGljIGNvdW50OwogICAgZnVuY3Rpb24gaW5jcmVtZW50KCkgZXh0ZXJuYWwgeyBjb3VudCsrOyB9CiAgICBmdW5jdGlvbiBkZWNyZW1lbnQoKSBleHRlcm5hbCB7IGNvdW50LS07IH0KfQ"
+  title="Counter.sol · deploy to Sei testnet"
+  description="Remix IDE with a minimal Counter contract preloaded. Deploy it to Sei testnet, then verify it with the Contract Verification plugin below."
+/>
 
 ### Setup and Configuration
 

--- a/evm/evm-wizard.mdx
+++ b/evm/evm-wizard.mdx
@@ -69,7 +69,7 @@ The OpenZeppelin Contract Wizard is a powerful interactive tool that simplifies 
 - **Consider Gas Costs**: More features generally mean higher deployment and operation costs
 - **Customize Post-Generation**: The wizard provides a starting point—most projects will require additional customization
 
-## Deploy from the browser
+## Try it: deploy from the browser
 
 Once the wizard generates your contract, you can compile and deploy it to Sei testnet without any local setup. The Remix sandbox below is preloaded with a sample OpenZeppelin ERC-20 — replace it with your generated code, compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask**.
 

--- a/evm/evm-wizard.mdx
+++ b/evm/evm-wizard.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'EVM Contract Wizard'
 description: 'Learn how to use the OpenZeppelin Contract Wizard to create secure, standard-compliant smart contracts for Sei EVM, with step-by-step guidance and best practices.'
 keywords: ['OpenZeppelin wizard', 'smart contract generator', 'ERC standards', 'Sei EVM', 'contract development']
 ---
+
+import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+import { AddSeiButton } from '/snippets/add-sei-button.jsx';
+
 The OpenZeppelin Contract Wizard is a powerful interactive tool that simplifies the creation of secure, standard-compliant smart contracts for Sei EVM. It provides a user-friendly interface for generating production-ready contract code based on OpenZeppelin's battle-tested libraries. Explore and create your custom smart contracts using the embedded wizard below.
 
 <iframe
@@ -64,6 +68,19 @@ The OpenZeppelin Contract Wizard is a powerful interactive tool that simplifies 
 - **Review Dependencies**: Note which OpenZeppelin libraries your contract imports
 - **Consider Gas Costs**: More features generally mean higher deployment and operation costs
 - **Customize Post-Generation**: The wizard provides a starting point—most projects will require additional customization
+
+## Deploy from the browser
+
+Once the wizard generates your contract, you can compile and deploy it to Sei testnet without any local setup. The Remix sandbox below is preloaded with a sample OpenZeppelin ERC-20 — replace it with your generated code, compile under **Solidity Compiler**, then **Deploy & Run** with **Environment** set to **Injected Provider — MetaMask**.
+
+<AddSeiButton network="testnet" label="Add Sei testnet" />
+
+<SandboxEmbed
+  kind="remix"
+  src="https://remix.ethereum.org/?#activate=solidity,fileManager&code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC4yNDsKCmltcG9ydCAiQG9wZW56ZXBwZWxpbi9jb250cmFjdHMvdG9rZW4vRVJDMjAvRVJDMjAuc29sIjsKCmNvbnRyYWN0IERlbW9Ub2tlbiBpcyBFUkMyMCB7CiAgICBjb25zdHJ1Y3RvcigpIEVSQzIwKCJEZW1vIFRva2VuIiwgIkRFTU8iKSB7CiAgICAgICAgX21pbnQobXNnLnNlbmRlciwgMV8wMDBfMDAwICogMTAgKiogZGVjaW1hbHMoKSk7CiAgICB9Cn0"
+  title="OpenZeppelin ERC-20 · deploy to Sei testnet"
+  description="Remix IDE preloaded with a sample OpenZeppelin ERC-20. Paste in your wizard output, compile, and deploy to Sei testnet."
+/>
 
 ## Learn More
 

--- a/evm/python-quickstart.mdx
+++ b/evm/python-quickstart.mdx
@@ -50,7 +50,7 @@ Nonce: 7
 
 Values are illustrative — your block number, and the queried address's balance and nonce, will differ. The chain ID is always `1329` on mainnet (`1328` on the atlantic-2 testnet).
 
-### Try it live
+## Try it live
 
 `web3.py` issues plain JSON-RPC under the hood — here are the same reads against Sei mainnet, no Python required.
 

--- a/evm/python-quickstart.mdx
+++ b/evm/python-quickstart.mdx
@@ -5,6 +5,8 @@ description: 'Connect to Sei from Python using web3.py — read chain data, then
 keywords: ['sei evm', 'python', 'web3.py', 'json-rpc', 'quickstart']
 ---
 
+import { RunSnippet } from '/snippets/run-snippet.jsx';
+
 Sei is fully EVM-compatible, so any standard Ethereum client works — including Python's [web3.py](https://web3py.readthedocs.io). This guide connects to Sei from a Python script, reads chain data with no credentials, then signs and broadcasts a transaction.
 
 ## Install
@@ -47,6 +49,22 @@ Nonce: 7
 ```
 
 Values are illustrative — your block number, and the queried address's balance and nonce, will differ. The chain ID is always `1329` on mainnet (`1328` on the atlantic-2 testnet).
+
+### Try it live
+
+`web3.py` issues plain JSON-RPC under the hood — here are the same reads against Sei mainnet, no Python required.
+
+<RunSnippet method="eth_chainId" network="mainnet" title="w3.eth.chain_id" description="The mainnet chain ID — decodes to 1329." />
+
+<RunSnippet method="eth_blockNumber" network="mainnet" title="w3.eth.block_number" description="Latest committed block on pacific-1." />
+
+<RunSnippet
+  method="eth_getBalance"
+  params={['0x0000000000000000000000000000000000000000', 'latest']}
+  network="mainnet"
+  title="w3.eth.get_balance(address)"
+  description="Wei balance of the example address — swap in your own. w3.from_wei(…, 'ether') converts it to SEI."
+/>
 
 ## Sending a Transaction
 

--- a/snippets/run-snippet.jsx
+++ b/snippets/run-snippet.jsx
@@ -57,6 +57,10 @@ export const RunSnippet = (props) => {
 
 	const hexToDecimal = (value) => {
 		if (typeof value !== 'string' || !/^0x[0-9a-fA-F]+$/.test(value)) return null;
+		// Only decode values that fit in a single 32-byte word (a uint256 quantity).
+		// Longer hex — contract bytecode, multi-word ABI returns — is not one number,
+		// so leave it raw rather than rendering a meaningless giant decimal.
+		if (value.length > 66) return null;
 		try {
 			return groupThousands(BigInt(value).toString(10));
 		} catch (e) {
@@ -97,26 +101,34 @@ export const RunSnippet = (props) => {
 	const decoded = decode !== 'off' && typeof result === 'string' ? hexToDecimal(result) : null;
 
 	const copyResult = () => {
-		if (typeof navigator !== 'undefined' && navigator.clipboard) {
-			navigator.clipboard.writeText(resultString);
+		const flashCopied = () => {
 			setCopied(true);
 			setTimeout(() => setCopied(false), 2000);
+		};
+		// Prefer the async Clipboard API; only flash "Copied" once the write resolves,
+		// so a rejected/denied write never shows a false confirmation.
+		if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+			navigator.clipboard.writeText(resultString).then(flashCopied, () => {});
+			return;
+		}
+		// Fallback for insecure (http://) or older contexts where navigator.clipboard
+		// is unavailable — copy via a hidden textarea + execCommand.
+		if (typeof document !== 'undefined') {
+			try {
+				const ta = document.createElement('textarea');
+				ta.value = resultString;
+				ta.style.position = 'fixed';
+				ta.style.opacity = '0';
+				document.body.appendChild(ta);
+				ta.select();
+				document.execCommand('copy');
+				document.body.removeChild(ta);
+				flashCopied();
+			} catch (e) {
+				/* clipboard unavailable — no-op */
+			}
 		}
 	};
-
-	// --- icons (nested) ---
-	const SpinnerIcon = () => (
-		<svg className='animate-spin h-4 w-4' xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'>
-			<circle className='opacity-25' cx='12' cy='12' r='10' stroke='currentColor' strokeWidth='4' />
-			<path className='opacity-75' fill='currentColor' d='M4 12a8 8 0 0 1 8-8v4a4 4 0 0 0-4 4H4z' />
-		</svg>
-	);
-
-	const PlayIcon = () => (
-		<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='currentColor'>
-			<path d='M8 5v14l11-7z' />
-		</svg>
-	);
 
 	// --- theme-agnostic surfaces (see theming note above) ---
 	const HAIRLINE = 'rgba(128, 128, 128, 0.25)';
@@ -157,7 +169,16 @@ export const RunSnippet = (props) => {
 					onMouseLeave={() => setBtnHover(false)}
 					className='inline-flex items-center gap-1.5 px-3 py-1.5 shrink-0 transition-colors'
 					style={buttonStyle}>
-					{phase === 'loading' ? <SpinnerIcon /> : <PlayIcon />}
+					{phase === 'loading' ? (
+							<svg className='animate-spin h-4 w-4' aria-hidden='true' xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'>
+								<circle className='opacity-25' cx='12' cy='12' r='10' stroke='currentColor' strokeWidth='4' />
+								<path className='opacity-75' fill='currentColor' d='M4 12a8 8 0 0 1 8-8v4a4 4 0 0 0-4 4H4z' />
+							</svg>
+						) : (
+							<svg aria-hidden='true' xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='currentColor'>
+								<path d='M8 5v14l11-7z' />
+							</svg>
+						)}
 					{phase === 'loading' ? 'Running…' : label || 'Run'}
 				</button>
 			</div>

--- a/snippets/run-snippet.jsx
+++ b/snippets/run-snippet.jsx
@@ -1,0 +1,210 @@
+// RunSnippet — a click-to-load "Try it" button for read-only EVM JSON-RPC calls.
+//
+// Sei's public EVM RPC endpoints return `access-control-allow-origin: *`, so a
+// read-only call can be issued straight from the browser with a plain `fetch`
+// POST — no SDK, no proxy. Mintlify's React runtime cannot import npm packages,
+// so this component uses only browser globals (fetch, BigInt).
+//
+// Theming note: Mintlify applies `dark:text-*` utilities (class strategy) but
+// NOT `dark:bg-*` / `dark:border-*` on custom-snippet container <div>s — verified
+// empirically. So surfaces and hairlines use theme-agnostic translucent inline
+// styles (rgba grey), which render correctly over both light and dark backdrops,
+// while text keeps the working `dark:text-*` classes.
+//
+// Usage in MDX:
+//   import { RunSnippet } from '/snippets/run-snippet.jsx';
+//
+//   <RunSnippet method="eth_blockNumber" />
+//   <RunSnippet
+//     method="eth_getBalance"
+//     params={["0x0000000000000000000000000000000000000000", "latest"]}
+//     network="testnet"
+//     description="Read the SEI balance of an address at the latest block."
+//   />
+export const RunSnippet = (props) => {
+	const {
+		method = 'eth_blockNumber',
+		params = [],
+		network = 'testnet',
+		endpoint,
+		label,
+		title,
+		description,
+		decode = 'auto'
+	} = props || {};
+
+	// --- config (kept inside the component: module-level decls crash in Mintlify) ---
+	const ENDPOINTS = {
+		testnet: 'https://evm-rpc-testnet.sei-apis.com',
+		mainnet: 'https://evm-rpc.sei-apis.com'
+	};
+	const rpcUrl = endpoint || ENDPOINTS[network] || ENDPOINTS.testnet;
+	const networkLabel = network === 'mainnet' ? 'pacific-1 · mainnet' : network === 'testnet' ? 'atlantic-2 · testnet' : network;
+
+	const requestBody = { jsonrpc: '2.0', id: 1, method, params };
+	const requestJson = JSON.stringify(requestBody, null, 2);
+
+	// --- state ---
+	const [phase, setPhase] = useState('idle'); // idle | loading | success | error
+	const [result, setResult] = useState(null);
+	const [errorMsg, setErrorMsg] = useState(null);
+	const [elapsed, setElapsed] = useState(null);
+	const [copied, setCopied] = useState(false);
+	const [btnHover, setBtnHover] = useState(false);
+
+	// --- helpers (nested) ---
+	const groupThousands = (s) => s.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+	const hexToDecimal = (value) => {
+		if (typeof value !== 'string' || !/^0x[0-9a-fA-F]+$/.test(value)) return null;
+		try {
+			return groupThousands(BigInt(value).toString(10));
+		} catch (e) {
+			return null;
+		}
+	};
+
+	const run = async () => {
+		setPhase('loading');
+		setErrorMsg(null);
+		setResult(null);
+		setElapsed(null);
+		const startedAt = typeof performance !== 'undefined' ? performance.now() : null;
+		try {
+			const response = await fetch(rpcUrl, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(requestBody)
+			});
+			const data = await response.json();
+			if (startedAt != null && typeof performance !== 'undefined') {
+				setElapsed(Math.round(performance.now() - startedAt));
+			}
+			if (data && data.error) {
+				setErrorMsg(data.error.message || 'RPC returned an error');
+				setPhase('error');
+				return;
+			}
+			setResult(data ? data.result : undefined);
+			setPhase('success');
+		} catch (err) {
+			setErrorMsg(err && err.message ? err.message : 'Request failed');
+			setPhase('error');
+		}
+	};
+
+	const resultString = result === undefined ? 'undefined' : JSON.stringify(result, null, 2);
+	const decoded = decode !== 'off' && typeof result === 'string' ? hexToDecimal(result) : null;
+
+	const copyResult = () => {
+		if (typeof navigator !== 'undefined' && navigator.clipboard) {
+			navigator.clipboard.writeText(resultString);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		}
+	};
+
+	// --- icons (nested) ---
+	const SpinnerIcon = () => (
+		<svg className='animate-spin h-4 w-4' xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'>
+			<circle className='opacity-25' cx='12' cy='12' r='10' stroke='currentColor' strokeWidth='4' />
+			<path className='opacity-75' fill='currentColor' d='M4 12a8 8 0 0 1 8-8v4a4 4 0 0 0-4 4H4z' />
+		</svg>
+	);
+
+	const PlayIcon = () => (
+		<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='currentColor'>
+			<path d='M8 5v14l11-7z' />
+		</svg>
+	);
+
+	// --- theme-agnostic surfaces (see theming note above) ---
+	const HAIRLINE = 'rgba(128, 128, 128, 0.25)';
+	const surfaceStyle = { backgroundColor: 'rgba(128, 128, 128, 0.08)' };
+	const monoStyle = { fontFamily: 'var(--sei-font-mono)' };
+	const codeStyle = { backgroundColor: 'rgba(128, 128, 128, 0.05)', fontFamily: 'var(--sei-font-mono)' };
+
+	const cardClass = 'not-prose w-full rounded-lg border overflow-hidden my-4';
+	const headerClass = 'flex items-center justify-between gap-3 px-4 py-2.5 border-b';
+	const labelClass = 'text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-500';
+	const preClass = 'm-0 px-4 py-3 text-sm overflow-x-auto text-neutral-700 dark:text-neutral-300';
+
+	const buttonStyle = {
+		backgroundColor: btnHover ? 'var(--sei-maroon-200)' : 'var(--sei-maroon-100)',
+		color: '#ffffff',
+		fontFamily: 'var(--sei-font-mono)',
+		textTransform: 'uppercase',
+		letterSpacing: '0.04em',
+		fontSize: '10px',
+		opacity: phase === 'loading' ? 0.7 : 1,
+		cursor: phase === 'loading' ? 'default' : 'pointer'
+	};
+
+	return (
+		<div className={cardClass} style={{ borderColor: HAIRLINE }}>
+			<div className={headerClass} style={{ ...surfaceStyle, borderBottomColor: HAIRLINE }}>
+				<div className='flex flex-col min-w-0'>
+					<span className='text-sm font-medium text-neutral-900 dark:text-white truncate' style={monoStyle}>
+						{title || method}
+					</span>
+					<span className='text-xs text-neutral-500 dark:text-neutral-500'>{networkLabel}</span>
+				</div>
+				<button
+					type='button'
+					onClick={run}
+					disabled={phase === 'loading'}
+					onMouseEnter={() => setBtnHover(true)}
+					onMouseLeave={() => setBtnHover(false)}
+					className='inline-flex items-center gap-1.5 px-3 py-1.5 shrink-0 transition-colors'
+					style={buttonStyle}>
+					{phase === 'loading' ? <SpinnerIcon /> : <PlayIcon />}
+					{phase === 'loading' ? 'Running…' : label || 'Run'}
+				</button>
+			</div>
+
+			{description ? (
+				<div className='px-4 pt-3 text-sm text-neutral-600 dark:text-neutral-400'>{description}</div>
+			) : null}
+
+			<div className='px-4 pt-3 pb-1'>
+				<span className={labelClass}>Request</span>
+			</div>
+			<pre className={preClass} style={codeStyle}>
+				{requestJson}
+			</pre>
+
+			{phase === 'success' ? (
+				<div className='border-t' style={{ borderTopColor: HAIRLINE }}>
+					<div className='flex items-center justify-between px-4 pt-3 pb-1'>
+						<span className={labelClass}>Response{elapsed != null ? ` · ${elapsed} ms` : ''}</span>
+						<button
+							type='button'
+							onClick={copyResult}
+							className='text-xs text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200 transition-colors'>
+							{copied ? 'Copied' : 'Copy'}
+						</button>
+					</div>
+					<pre className={preClass} style={codeStyle}>
+						{resultString}
+					</pre>
+					{decoded ? (
+						<div className='px-4 pb-3 text-xs text-neutral-500 dark:text-neutral-500' style={monoStyle}>
+							= {decoded} (decimal)
+						</div>
+					) : null}
+				</div>
+			) : null}
+
+			{phase === 'error' ? (
+				<div className='border-t' style={{ borderTopColor: HAIRLINE }}>
+					<div className='px-4 pt-3 pb-1'>
+						<span className={labelClass}>Error</span>
+					</div>
+					<pre className={`${preClass} text-red-600 dark:text-red-400`} style={codeStyle}>
+						{errorMsg}
+					</pre>
+				</div>
+			) : null}
+		</div>
+	);
+};

--- a/snippets/sandbox-embed.jsx
+++ b/snippets/sandbox-embed.jsx
@@ -1,0 +1,157 @@
+// SandboxEmbed — a click-to-load iframe wrapper for external runnable-code sandboxes.
+//
+// Mintlify's React runtime cannot import npm (so no @stackblitz/sdk, no Sandpack
+// library) and the hosted site cannot set response headers (so no cross-origin-
+// isolated WebContainers). This component therefore embeds only SELF-SUFFICIENT
+// pure-iframe URLs:
+//   • CodeSandbox /embed  — Tier 2: editable/runnable viem/ethers TypeScript
+//   • Remix IDE           — Tier 3: Solidity compile + deploy to Sei testnet
+//
+// The <iframe> src is deferred until the reader clicks, so a page with several
+// embeds pays nothing on load (Mintlify has no dynamic import / React.lazy).
+// No `sandbox` attribute is set and `cross-origin-isolated` is intentionally
+// omitted: every working iframe already in this repo (in-app-swaps, videos,
+// snapshot, faucet) sets neither, and a restrictive sandbox is the most common
+// cause of a blank CodeSandbox/Remix frame.
+//
+// Theming note: surfaces/hairlines use theme-agnostic translucent inline styles
+// because Mintlify does not apply `dark:bg-*` / `dark:border-*` to custom-snippet
+// container <div>s (only `dark:text-*` works).
+//
+// Usage in MDX:
+//   import { SandboxEmbed } from '/snippets/sandbox-embed.jsx';
+//
+//   // Tier 2 — CodeSandbox (browser-bundled template; verify it runs anonymously)
+//   <SandboxEmbed
+//     kind="codesandbox"
+//     src="https://codesandbox.io/embed/<id>?view=split&hidenavigation=1&theme=dark"
+//     title="viem · read Sei testnet"
+//     description="Edit and re-run this viem example against Sei testnet."
+//   />
+//
+//   // Tier 3 — Remix IDE (code= must be base64URL: +/→-_, no padding)
+//   <SandboxEmbed
+//     kind="remix"
+//     src="https://remix.ethereum.org/?#activate=solidity,fileManager&code=<base64url>"
+//     title="Counter.sol · deploy to Sei testnet"
+//     description="Compile in-browser, then deploy via MetaMask on Sei testnet or Remix's External HTTP Provider set to https://evm-rpc-testnet.sei-apis.com."
+//   />
+export const SandboxEmbed = (props) => {
+	const { src, kind = 'codesandbox', title, description, height, label } = props || {};
+
+	// --- config (kept inside the component: module-level decls crash in Mintlify) ---
+	const KINDS = {
+		codesandbox: { name: 'CodeSandbox', host: 'codesandbox.io', defaultHeight: 500 },
+		remix: { name: 'Remix IDE', host: 'remix.ethereum.org', defaultHeight: 620 },
+		stackblitz: { name: 'StackBlitz', host: 'stackblitz.com', defaultHeight: 500 }
+	};
+	const meta = KINDS[kind] || KINDS.codesandbox;
+	const frameHeight = typeof height === 'number' ? height : meta.defaultHeight;
+
+	// Permissions kept minimal. `cross-origin-isolated` is deliberately NOT
+	// requested — it is inert unless the parent page is COOP/COEP isolated, which
+	// Mintlify cannot configure.
+	const allowAttr = 'clipboard-read; clipboard-write';
+
+	// --- state ---
+	const [loaded, setLoaded] = useState(false);
+	const [btnHover, setBtnHover] = useState(false);
+
+	// --- theme-agnostic surfaces (see theming note above) ---
+	const HAIRLINE = 'rgba(128, 128, 128, 0.25)';
+	const surfaceStyle = { backgroundColor: 'rgba(128, 128, 128, 0.08)' };
+	const monoStyle = { fontFamily: 'var(--sei-font-mono)' };
+
+	const cardClass = 'not-prose w-full rounded-lg border overflow-hidden my-4';
+	const headerClass = 'flex items-center justify-between gap-3 px-4 py-2.5 border-b';
+	const buttonStyle = {
+		backgroundColor: btnHover ? 'var(--sei-maroon-200)' : 'var(--sei-maroon-100)',
+		color: '#ffffff',
+		fontFamily: 'var(--sei-font-mono)',
+		textTransform: 'uppercase',
+		letterSpacing: '0.04em',
+		fontSize: '10px',
+		cursor: 'pointer'
+	};
+
+	// --- icons (nested) ---
+	const PlayIcon = () => (
+		<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='currentColor'>
+			<path d='M8 5v14l11-7z' />
+		</svg>
+	);
+
+	const ExternalIcon = () => (
+		<svg xmlns='http://www.w3.org/2000/svg' width='13' height='13' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
+			<path d='M14 5h5v5' />
+			<path d='M19 5l-9 9' />
+			<path d='M19 14v5a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1h5' />
+		</svg>
+	);
+
+	return (
+		<div className={cardClass} style={{ borderColor: HAIRLINE }}>
+			<div className={headerClass} style={{ ...surfaceStyle, borderBottomColor: HAIRLINE }}>
+				<div className='flex flex-col min-w-0'>
+					<span className='text-sm font-medium text-neutral-900 dark:text-white truncate' style={monoStyle}>
+						{title || meta.name}
+					</span>
+					<span className='text-xs text-neutral-500 dark:text-neutral-500'>{meta.name}</span>
+				</div>
+				<div className='flex items-center gap-3 shrink-0'>
+					{src ? (
+						<a
+							href={src}
+							target='_blank'
+							rel='noopener noreferrer'
+							className='inline-flex items-center gap-1 text-xs text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200 transition-colors'>
+							Open <ExternalIcon />
+						</a>
+					) : null}
+					{!loaded && src ? (
+						<button
+							type='button'
+							onClick={() => setLoaded(true)}
+							onMouseEnter={() => setBtnHover(true)}
+							onMouseLeave={() => setBtnHover(false)}
+							className='inline-flex items-center gap-1.5 px-3 py-1.5 transition-colors'
+							style={buttonStyle}>
+							<PlayIcon />
+							{label || 'Load editor'}
+						</button>
+					) : null}
+				</div>
+			</div>
+
+			{description ? (
+				<div className='px-4 pt-3 pb-1 text-sm text-neutral-600 dark:text-neutral-400'>{description}</div>
+			) : null}
+
+			{!src ? (
+				<div className='px-4 py-6 text-sm text-red-600 dark:text-red-400' style={monoStyle}>
+					SandboxEmbed: missing required `src`.
+				</div>
+			) : loaded ? (
+				<iframe
+					src={src}
+					title={title || meta.name}
+					className='w-full block border-0'
+					style={{ height: frameHeight + 'px', backgroundColor: 'rgba(128, 128, 128, 0.05)' }}
+					allow={allowAttr}
+					loading='lazy'
+					allowFullScreen
+				/>
+			) : (
+				<button
+					type='button'
+					onClick={() => setLoaded(true)}
+					className='w-full flex flex-col items-center justify-center gap-2 text-neutral-500 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors'
+					style={{ height: frameHeight + 'px', cursor: 'pointer', ...surfaceStyle }}>
+					<PlayIcon />
+					<span className='text-sm' style={monoStyle}>Click to load {meta.name}</span>
+					<span className='text-xs'>Loads {meta.host} in an embedded editor</span>
+				</button>
+			)}
+		</div>
+	);
+};

--- a/snippets/sandbox-embed.jsx
+++ b/snippets/sandbox-embed.jsx
@@ -46,7 +46,10 @@ export const SandboxEmbed = (props) => {
 		stackblitz: { name: 'StackBlitz', host: 'stackblitz.com', defaultHeight: 500 }
 	};
 	const meta = KINDS[kind] || KINDS.codesandbox;
-	const frameHeight = typeof height === 'number' ? height : meta.defaultHeight;
+	// Coerce so a string height from MDX (height="600") is honored, and guard against
+	// 0 / negative / NaN, which would otherwise render an invisible iframe.
+	const parsedHeight = Number(height);
+	const frameHeight = Number.isFinite(parsedHeight) && parsedHeight > 0 ? parsedHeight : meta.defaultHeight;
 
 	// Permissions kept minimal. `cross-origin-isolated` is deliberately NOT
 	// requested — it is inert unless the parent page is COOP/COEP isolated, which
@@ -76,13 +79,13 @@ export const SandboxEmbed = (props) => {
 
 	// --- icons (nested) ---
 	const PlayIcon = () => (
-		<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='currentColor'>
+		<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
 			<path d='M8 5v14l11-7z' />
 		</svg>
 	);
 
 	const ExternalIcon = () => (
-		<svg xmlns='http://www.w3.org/2000/svg' width='13' height='13' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
+		<svg xmlns='http://www.w3.org/2000/svg' width='13' height='13' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' aria-hidden='true'>
 			<path d='M14 5h5v5' />
 			<path d='M19 5l-9 9' />
 			<path d='M19 14v5a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1h5' />


### PR DESCRIPTION
## What is the purpose of the change?

Adds interactive, runnable content across the EVM docs — read-only **"Run"** buttons and click-to-load **editor/deploy** embeds — so developers can try JSON-RPC calls and deploy contracts without leaving the docs.

Originally scoped to 5 example pages; now extended across the EVM **examples**, the **Smart Contracts** group, and the **debugging** page — **18 pages total**, built from two self-contained Mintlify snippets plus the existing `AddSeiButton`.

## Snippets

**`snippets/run-snippet.jsx` — Tier 1: read-only "Run" buttons**
- Click-to-run read-only JSON-RPC issued straight from the browser to Sei's public RPC (endpoints send `access-control-allow-origin: *`, so no proxy is needed). Hex results auto-decode to decimal; copy + request-timing included; RPC errors surface in a dedicated panel.

**`snippets/sandbox-embed.jsx` — Tier 2 & 3: click-to-load editor embeds**
- **Tier 2 (CodeSandbox)** — editable, anonymously-runnable viem/ethers TypeScript reading Sei testnet.
- **Tier 3 (Remix IDE)** — compile + deploy Solidity to Sei testnet from the browser; the Solidity source is base64-encoded directly into the Remix URL, so each embed is self-contained with nothing to host. Paired with `AddSeiButton`.
- The iframe `src` is deferred until the reader clicks, so pages pay nothing on load.

## Pages wired

**Examples (`evm/evm-parity/examples/`)**
- **Tier 1 + Tier 2:** viem-quickstart, ethers-quickstart
- **Tier 1 Run:** transaction-lifecycle, multicall (raw `eth_call` to Multicall3 at `0xcA11…CA11`), error-handling (a real revert + a real RPC argument error), wagmi-react, sei-precompiles (Bank precompile)
- **Tier 3 Remix deploy:** deploy-verify (Counter), erc20 (OZ ERC-20), erc721 (OZ ERC-721), erc1155 (OZ ERC-1155)

**Smart Contracts group (`evm/*`)**
- **evm-general, evm-hardhat, evm-foundry:** Tier-1 `eth_chainId` checks (testnet + mainnet, to validate the RPC endpoints used in config) + Tier-3 Remix "no-install deploy" (Counter)
- **python-quickstart:** Tier-1 reads mirroring the web3.py example (`chain_id` / `block_number` / `get_balance`)
- **evm-wizard:** Tier-3 Remix (sample OZ ERC-20 — paste in your wizard output and deploy)
- **evm-verify-contracts:** Tier-3 Remix (Counter) inside the Remix verification section

**Debugging (`evm/debugging-contracts`)**
- Tier-1 diagnostics mapping the page's `cast` commands: `cast chain-id` / `gas-price` / `nonce` / `balance`

_Intentionally skipped:_ pointer-contracts (no clean anonymous read — needs a user-supplied CosmWasm address) and solidity-resources (links page). No new Tier-2 (CodeSandbox) embeds were added on the additional pages.

## Notes / verification

- **Verified via `mint dev` + headless Chrome:** all 18 pages return HTTP 200, every component mounts, **zero page errors, zero console errors**. Interactive checks: multicall Run → live `eth_call` decoded to the current block number (~300 ms); error-handling Run → red "execution reverted" panel; Remix embeds load the preloaded contract and frame inside Mintlify with no CSP/X-Frame refusal. Every wired RPC call confirmed live against Sei mainnet/testnet.
- **Mintlify constraints respected:** no npm imports, named exports, all declarations inside the component. Surfaces use theme-agnostic translucent inline styles because Mintlify doesn't apply `dark:bg-*` / `dark:border-*` to custom-snippet container `<div>`s (only `dark:text-*` works).
- **Follow-ups (not in this PR):** the two CodeSandbox sandboxes (`cgtx45`, `qs82lw`) were created anonymously via the Define API and should be re-created under a Sei-owned CodeSandbox account for durability/branding. Tier-2 for the python quickstart is deferred (web3.py can't run in CodeSandbox's JS-only browser bundler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
