### PR TITLE
docs: reconcile SSTORE gas to 72,000 (same on both networks, Prop #109)

### DIFF
--- a/ai/sei-skill/index.mdx
+++ b/ai/sei-skill/index.mdx
@@ -17,7 +17,7 @@ AI assistants are trained on broad Ethereum knowledge, not Sei's specifics. With
 |---|---|
 | `maxFeePerGas` in transactions | Legacy `gasPrice` (Sei doesn't use EIP-1559 basefee) |
 | "Finality takes ~12 confirmations" | Instant finality — 1 confirmation is final |
-| SSTORE costs 20,000 gas | SSTORE varies: 72,000 on testnet, 20,000 on mainnet (governance-adjustable) |
+| SSTORE costs 20,000 gas | SSTORE costs 72,000 gas — the same on mainnet and testnet (governance-adjustable on-chain parameter; [reference](/evm/differences-with-ethereum#sstore-gas-cost)) |
 | `PREVRANDAO` for randomness | PREVRANDAO is not random on Sei — use Pyth VRF or Chainlink VRF |
 | Generic ERC-20 patterns | Sei precompiles, pointer contracts, dual-address UX |
 | `@sei-js/evm` imports | `@sei-js/precompiles` (the current package name) |

--- a/ai/sei-skill/prompts.mdx
+++ b/ai/sei-skill/prompts.mdx
@@ -19,7 +19,7 @@ Deploy a Solidity contract to Sei mainnet and verify it on Seiscan
 How do I call the Staking precompile from Solidity to delegate SEI?
 ```
 ```
-Why is SSTORE so expensive on Sei testnet compared to mainnet?
+Why does SSTORE cost more on Sei than on Ethereum, and how should I budget gas for storage writes?
 ```
 ```
 How do I use the Bank precompile to query a native denom balance?

--- a/evm/differences-with-ethereum.mdx
+++ b/evm/differences-with-ethereum.mdx
@@ -181,7 +181,9 @@ On Sei, the `SSTORE` opcode gas cost is configurable as an on-chain parameter, m
 
 This provides flexibility to tune storage costs based on EVM state size and network conditions.
 
-Currently, the `SSTORE` gas cost is set to the non-standard value of **72,000 gas**.
+Currently, the `SSTORE` gas cost is set to the non-standard value of **72,000 gas**, and this is the same on both mainnet (`pacific-1`) and testnet (`atlantic-2`) — it does not vary by network. It was set by governance [Proposal #109](https://www.mintscan.io/sei/proposals/109) ("Update EVM SSTORE set gas to 72000"), which changed the `evm` module parameter `KeySeiSstoreSetGasEIP2200` to `72000`.
+
+To confirm the real cost yourself, use a live `eth_estimateGas` call against a Sei RPC. Note that a Foundry `forge test --gas-report --fork-url <sei rpc>` report forks chain *state* but applies revm's standard EVM gas schedule, so it reports the Ethereum cost (~22,100) rather than Sei's — it is useful for relative profiling of your own logic, not for the absolute storage-write cost.
 
 <Info>Since `SSTORE` is a governance-controlled parameter, this value may change in the future through a governance proposal.</Info>
 

--- a/evm/evm-parity/gas-and-fees.mdx
+++ b/evm/evm-parity/gas-and-fees.mdx
@@ -55,7 +55,7 @@ const feeData = await provider.getFeeData();
 
 ## SSTORE Cost
 
-The gas cost of `SSTORE` (writing to contract storage) is governance-adjustable on Sei. Do not hard-code storage write estimates in your application.
+The gas cost of `SSTORE` (writing to contract storage) is governance-adjustable on Sei. It is currently **72,000 gas** — the same on mainnet and testnet (see [Divergence from Ethereum](/evm/differences-with-ethereum#sstore-gas-cost)) — but treat that as the current value, not a constant: do not hard-code storage write estimates in your application.
 
 Always use `eth_estimateGas` for any transaction that writes to storage:
 
@@ -81,6 +81,8 @@ const gas = await provider.estimateGas({
 ```
 
 </CodeGroup>
+
+<Warning>A Foundry `forge test --gas-report --fork-url <sei rpc>` report forks chain *state* but runs revm's standard EVM gas schedule, so it shows `SSTORE` at the Ethereum cost (~22,100) rather than Sei's ~72,000. Use it for relative profiling of your own logic; estimate the absolute storage-write cost with a live `eth_estimateGas` against a Sei RPC.</Warning>
 
 ## Summary
 

--- a/skill.md
+++ b/skill.md
@@ -38,7 +38,7 @@ npx skills add sei-ecosystem    # apps / integrations only
 ## Critical facts — apply to every answer
 
 1. **400ms block time, instant finality** — use `tx.wait(1)`, never `tx.wait(12)`
-2. **SSTORE gas is 72,000 on Sei** — both mainnet (pacific-1) and testnet (atlantic-2): 72,000 gas per cold write (governance proposal #240; governance-adjustable)
+2. **SSTORE gas is 72,000 on Sei** — the same on both mainnet (pacific-1) and testnet (atlantic-2); it does not vary by network. Set via governance (mainnet Proposal #109, "Update EVM SSTORE set gas to 72000", which set the `evm` param `KeySeiSstoreSetGasEIP2200` to `72000`), so it is adjustable and can change — confirm the live value at https://docs.sei.io/evm/differences-with-ethereum#sstore-gas-cost
 3. **Use legacy `gasPrice`** — Sei has no base fee burn; prefer `gasPrice` over EIP-1559 `maxFeePerGas` / `maxPriorityFeePerGas`
 4. **Minimum gas price: 50 gwei**
 5. **Block gas limit: 12.5M per block**


### PR DESCRIPTION
## Problem

The docs contradicted themselves on the SSTORE (storage write) gas cost, which confuses developers and any AI assistant trained on the docs:

- `skill.md` — "72,000 on both mainnet and testnet"
- `ai/sei-skill/index.mdx` — "72,000 on testnet, 20,000 on mainnet"
- `ai/sei-skill/prompts.mdx` — example prompt implying testnet > mainnet

These can't all be right.

## Resolution

**SSTORE is 72,000 gas — the same on `pacific-1` and `atlantic-2`** (it does **not** vary by network), governance-adjustable.

**Verified empirically.** I measured the marginal cost of a cold (zero→nonzero) storage write via `eth_estimateGas` against both live EVM RPCs (contract-creation bytecode doing 0/1/2/3 fresh writes). Both networks returned byte-for-byte identical estimates; the per-write marginal is **~74,100 = 72,000 base + 2,100 EIP-2929 cold-access** + minor overhead. (Standard Ethereum would be ~22,100.)

**Source of the value:** mainnet governance [Proposal #109 "Update EVM SSTORE set gas to 72000"](https://www.mintscan.io/sei/proposals/109) (PASSED), which set the `evm` module param `KeySeiSstoreSetGasEIP2200 = "72000"`. (The previously-cited "#240" was incorrect — it doesn't exist on mainnet, and on testnet it's a `v6.3.0` upgrade.)

## Changes

- **`skill.md`**, **`ai/sei-skill/index.mdx`**, **`ai/sei-skill/prompts.mdx`** — state 72,000, same on both networks, governance-adjustable; cite Prop #109; the example prompt no longer implies a false testnet-vs-mainnet difference.
- **`evm/differences-with-ethereum.mdx`** (canonical reference) — notes same-on-both + Prop #109, and warns that a `forge test --gas-report --fork-url` report forks *state* but applies revm's standard EVM schedule (~22,100), so it understates Sei's cost — use live `eth_estimateGas`.
- **`evm/evm-parity/gas-and-fees.mdx`** — adds the current value, links the canonical page, and adds the same fork-report caveat.

All SSTORE statements across the affected docs now agree and point to the canonical reference.

## Scope note

This PR contains **only** the SSTORE reconciliation in already-tracked docs. It intentionally **excludes** the in-progress Agent Skills registry work (`.mintlify/skills/`, `ai/skills.mdx`, `evm/templates.mdx`, `snippets/skills-registry.jsx`, and the related `.gitignore`/`docs.json` changes), which will ship separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)