### PR TITLE
docs(sip-03): add Seistream association tool, drop closed Stargate pools

### DIFF
--- a/learn/sip-03-migration.mdx
+++ b/learn/sip-03-migration.mdx
@@ -2,7 +2,7 @@
 title: 'SIP-03 Migration Guide'
 sidebarTitle: 'SIP-03 Migration'
 description: 'Practical steps and resources for users and exchanges migrating during SIP-03, including asset transfer, USDC, and exchange migration guidance.'
-keywords: ['SIP-03', 'migration', 'asset transfer', 'USDC on Sei', 'Keplr', 'Leap', 'Compass', 'EVM wallet', 'exchange migration', 'FundsForwarder', 'address association', 'Ledger', 'hardware wallet', 'mnemonic', 'private key export', 'coin type 118', 'coin type 60']
+keywords: ['SIP-03', 'migration', 'asset transfer', 'USDC on Sei', 'Keplr', 'Leap', 'Compass', 'EVM wallet', 'exchange migration', 'FundsForwarder', 'address association', 'Seistream', 'Ledger', 'hardware wallet', 'mnemonic', 'private key export', 'coin type 118', 'coin type 60']
 ---
 <Danger>
 
@@ -45,8 +45,8 @@ If you hold any of the following IBC assets on Sei, take action before [Proposal
 
 | Asset | Token contract | Action(s) | Possible route(s) | Support |
 | :---- | :---- | :---- | :---- | :---- |
-| **USDC.n (USDC via Noble)** | [seiscan](https://seiscan.io/address/0x3894085ef7ff0f0aedf52e2a2704928d1ec074f1) [mintscan](https://www.mintscan.io/sei/assets/ibc%2FCA6FBFAF399474A06263E10D0CE5AEBBE15189D6D4B2DD9ADE61007E68EB9DB0) | Swap to native USDC or migrate via CCTP | [Saphyre](https://saphyre.xyz/swap?inputCurrency=0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1&outputCurrency=0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392), [Symphony](https://symph.ag/), or [Stargate](https://stargate.finance/?srcChain=sei&srcToken=0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) | [Sei blog](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/) [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei?ref=blog.sei.io) |
-| **USDT.kava (USDT via Kava)** | [seiscan](https://seiscan.io/token/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) [mintscan](https://www.mintscan.io/sei/assets/ibc%2F6C00E4AA0CC7618370F81F7378638AE6C48EFF8C9203CE1C2357012B440EBDB7)| Swap via Symphony or bridge out to Kava | [Symphony](https://symph.ag/), [Stargate](https://stargate.finance/?srcChain=sei&srcToken=0xB75D0B03c06A926e488e2659DF1A861F860bD3d1) | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
+| **USDC.n (USDC via Noble)** | [seiscan](https://seiscan.io/address/0x3894085ef7ff0f0aedf52e2a2704928d1ec074f1) [mintscan](https://www.mintscan.io/sei/assets/ibc%2FCA6FBFAF399474A06263E10D0CE5AEBBE15189D6D4B2DD9ADE61007E68EB9DB0) | Swap to native USDC or migrate via CCTP | [Saphyre](https://saphyre.xyz/swap?inputCurrency=0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1&outputCurrency=0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392), [Symphony](https://symph.ag/), or [CCTP Exchange](https://cctp.exchange/) | [Sei blog](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/) [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei?ref=blog.sei.io) |
+| **USDT.kava (USDT via Kava)** | [seiscan](https://seiscan.io/token/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) [mintscan](https://www.mintscan.io/sei/assets/ibc%2F6C00E4AA0CC7618370F81F7378638AE6C48EFF8C9203CE1C2357012B440EBDB7)| Swap to a native asset via Symphony | [Symphony](https://symph.ag/) | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
 | **USDCso (Wormhole, Solana)** | [mintscan](https://www.mintscan.io/sei/assets/factory%2Fsei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l%2F9fELvUhFo6yWL34ZaLgPbCPzdk9MD1tAzMycgH45qShH) | Bridge out to Solana via Wormhole | [Portal Bridge (legacy)](https://legacy.portalbridge.com/#/transfer) | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) [Discord](https://discord.com/invite/sei) |
 | **Wormhole-bridged WETH** | [mintscan](https://www.mintscan.io/sei/assets/factory%2Fsei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l%2F4tLQqCLaoKKfNFuPjA9o39YbKUwhR1F8N29Tz3hEbfP2) | Bridge out to Ethereum via Wormhole | [Portal Bridge (legacy)](https://legacy.portalbridge.com/#/transfer) | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
 | **USDCet (Wormhole, Ethereum)** | [mintscan](https://www.mintscan.io/sei/assets/factory%2Fsei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l%2FHq4tuDzhRBnxw3tFA5n6M52NVMVcC19XggbyDiJKCD6H) | Bridge out to Ethereum via Wormhole | [Portal Bridge (legacy)](https://legacy.portalbridge.com/#/transfer) | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
@@ -83,12 +83,33 @@ Native USDC and Circle's CCTP V2 are now supported on Sei. USDC from Noble (USDC
 
 **Migrate (larger amounts):**
 
-- **Manual migration:** Bridge USDC.n via [Stargate](https://stargate.finance/?srcChain=sei&srcToken=0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) to an intermediary chain with CCTP v1 and v2 (e.g., Base), then use CCTP to burn/mint native USDC back to Sei.
-- Other useful bridging frontends: [CCTP Exchange](https://cctp.exchange/)
+USDC.n reached Sei over IBC from Noble, so larger balances are best migrated to native USDC by routing back through Noble — this avoids the slippage of a direct DEX swap.
+
+- IBC-transfer your USDC.n from Sei back to Noble, where it becomes native Noble USDC, then use Circle's CCTP to mint native USDC on Sei. [CCTP Exchange](https://cctp.exchange/) is a useful frontend for the CCTP leg.
+
+Complete this **before** the SIP-03 upgrade, while IBC routing through Noble is still available.
 
 **For DeFi suppliers of USDC.n (Yei, Takara Lend, etc.):**
 
 - Wind down and withdraw your positions **before** migrating to native USDC. Failure to do so before the SIP-03 upgrade may result in inability to access your supplied assets.
+
+### 3) Address Association (Seistream)
+
+[Seistream's SIP-03 migration page](https://seistream.app/migrate-sip03) links your EVM (`0x...`) and Cosmos (`sei1...`) addresses for the **native SEI token** in three guided steps. It is a community-built tool that streamlines the standard association flow.
+
+Address association is the one-time, on-chain step that links your `0x...` and `sei1...` addresses so a single key controls both. It must be completed **before** the SIP-03 upgrade — afterward, Cosmos (`sei1...`) interfaces stop working and addresses can no longer be associated. See [Account Linking](/learn/accounts) for how association works under the hood.
+
+What the tool does:
+
+1. **Connect wallet** — connect any EVM wallet with an injected provider (MetaMask, Keplr, Rabby, Compass, Tangem, Trust Wallet, OKX, and most others).
+2. **Gas + association** — cover the small amount of SEI needed for gas (Seistream provides a mainnet faucet to help), then submit the transaction that associates your `0x...` and `sei1...` addresses on-chain. Any outgoing EVM transaction registers the link automatically.
+3. **Transfer from Cosmos** — send your existing native SEI from the old Cosmos wallet to the linked `sei1...` address, where it becomes spendable from your EVM wallet.
+
+This is a streamlined alternative to the manual association flow in [Migrating a hardware or mnemonic-only wallet](#migrating-a-hardware-or-mnemonic-only-wallet).
+
+<Warning>
+Seistream handles association for the **native SEI token only**. For USDC, USDT, ATOM, WBTC, and other IBC-bridged assets, use the [IBC Asset Migration Table](#ibc-asset-migration-table). Seistream is a third-party tool; its inclusion here is not an endorsement, and you should do your own research before connecting a wallet.
+</Warning>
 
 ## Migrating a hardware or mnemonic-only wallet
 
@@ -108,6 +129,10 @@ For background, see [HD Paths and Coin Types](/learn/accounts#hd-paths-and-coin-
 ### Migration steps
 
 This works because every account has exactly one EVM (`0x...`) address and one Cosmos (`sei1...`) address, both derived from the same key. Funds sent to the new account's `sei1...` address are therefore spendable from the EVM wallet that holds its `0x...` address.
+
+<Tip>
+Prefer a guided flow? [Seistream's SIP-03 migration tool](https://seistream.app/migrate-sip03) walks through these same steps — connect an EVM wallet, cover gas, associate addresses, then transfer native SEI from the Cosmos side. See [Address Association (Seistream)](#3-address-association-seistream). It covers native SEI only; the manual steps below work for any wallet you control.
+</Tip>
 
 <Steps>
 

--- a/snippets/ecosystem-contracts.jsx
+++ b/snippets/ecosystem-contracts.jsx
@@ -88,18 +88,8 @@ export const EcosystemContracts = () => {
 		},
 		{
 			Protocol: 'Stargate',
-			'Contract Address': '0x45d417612e177672958dc0537c45a8f8d754ac2e',
-			'Contract Name': 'StargatePoolUSDC'
-		},
-		{
-			Protocol: 'Stargate',
 			'Contract Address': '0x873cfB4bAe1Ab6A5DE753400e9d0616e10Dced22',
 			'Contract Name': 'Treasurer'
-		},
-		{
-			Protocol: 'Stargate',
-			'Contract Address': '0x0db9afb4c33be43a0a0e396fd1383b4ea97ab10a',
-			'Contract Name': 'StargatePoolMigratable'
 		},
 		{
 			Protocol: 'Stargate',


### PR DESCRIPTION
## Summary

Updates the SIP-03 migration guide and the ecosystem-contracts registry to add the Seistream address-association tool and remove migration routes/pools that are now closed.

### `learn/sip-03-migration.mdx`
- **New "Address Association (Seistream)" section** describing [seistream.app/migrate-sip03](https://seistream.app/migrate-sip03) — a community-built tool that links a user's EVM (`0x…`) and Cosmos (`sei1…`) addresses for the **native SEI token** in three steps (connect wallet → gas + association → transfer from Cosmos). Includes a cross-link `Tip` from the manual hardware/mnemonic-wallet flow. Faucet wording is deliberately scoped to what the live page supports (the page does not advertise gas coverage as a hard guarantee).
- **Removed the closed Stargate USDC.n and USDT.kava routes** from the IBC asset migration table.
- **Rewrote USDC.n "Migrate (larger amounts)"** to the real IBC path — USDC.n → Noble (IBC) → Circle CCTP → native USDC on Sei, with CCTP Exchange as the CCTP-leg frontend — and dropped the dead `brrr.fun` batching tool.

### `snippets/ecosystem-contracts.jsx`
- **Removed the two wound-down Stargate pools.** Despite its name, `StargatePoolUSDC` (`0x45d417…`) is backed by **USDC.n** (`token()` → `0x3894085…`, symbol `USDC.n`), not native USDC; `StargatePoolMigratable` (`0x0db9af…`) is backed by **USDT.kava**. Both verified on-chain via `token()`/`symbol()`. `StargateOFT` (WETH) and the shared infra contracts (`FeeLibV1`, `Treasurer`, `TokenMessaging`) are retained, since Stargate itself remains operational.

## Verification
- Confirmed zero remaining Stargate/brrr.fun references on the migration page; `evm/bridging/layerzero.mdx` (LayerZero contract ref) and `evm/sei-js/ledger.mdx` (`@cosmjs/stargate`) are intentionally untouched.
- Verified all in-page anchors resolve and the new `Tip`/`Warning` callouts are well-formed.
- Verified the ecosystem-contracts data array stays syntactically valid after removing the two objects.

## Follow-up (not in this PR)
- `llms-full.txt` is generated and still mirrors the pre-edit content (old Stargate routes ~L1491–1529 and the removed pool list ~L40670+). It should be regenerated so the LLM-facing copy matches. No generation script was found in `package.json`; happy to run whatever command the team uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)