### PR TITLE
ci: enable UCI AI review and assist workflows

### DIFF
--- a/.github/workflows/ai-assist.yml
+++ b/.github/workflows/ai-assist.yml
@@ -1,0 +1,22 @@
+name: AI Assistant
+on:
+  issue_comment:
+    types: [ created ]
+  pull_request_review_comment:
+    types: [ created ]
+  pull_request_review:
+    types: [ submitted ]
+jobs:
+  assistant:
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.12
+    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@258d2c3216d54872b33ac07430d23c847fc239ca
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    secrets: inherit
+    with:
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.12
+      uci-ref: 258d2c3216d54872b33ac07430d23c847fc239ca
+      allowed-team: 'sei-protocol/sei-core'

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,18 @@
+name: AI Review
+on:
+  pull_request:
+    types: [ opened, ready_for_review, synchronize, reopened ]
+jobs:
+  ai-review:
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.12
+    uses: sei-protocol/uci/.github/workflows/ai-review.yml@258d2c3216d54872b33ac07430d23c847fc239ca
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+      id-token: write
+    secrets: inherit
+    with:
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.12
+      uci-ref: 258d2c3216d54872b33ac07430d23c847fc239ca
+      enable-cursor: false # Disabled for now to avoid duplicate review if Cursor Bugbot is enabled on the repo.


### PR DESCRIPTION
## What is the purpose of the change?

Adds CI automation (no documentation content changes). Ports [sei-protocol/sei-chain#3651](https://github.com/sei-protocol/sei-chain/pull/3651) — "Enable UCI AI review and assist" — to the docs repo so the same shared AI review/assist pipeline runs here.

## Describe the changes to the documentation

Two new GitHub Actions workflows, each a thin caller of a `sei-protocol/uci` reusable workflow pinned to **v0.0.12** (`258d2c3216d54872b33ac07430d23c847fc239ca`):

- **`.github/workflows/ai-assist.yml`** — AI Assistant, triggered on `issue_comment`, `pull_request_review_comment`, and `pull_request_review`. Gated to the `sei-protocol/sei-core` team.
- **`.github/workflows/ai-review.yml`** — AI Review, triggered on `pull_request` (`opened`, `ready_for_review`, `synchronize`, `reopened`).

Faithful to the source PR, with one deliberate deviation: `enable-cursor` stays `false`, but its inline comment is reworded to drop the sei-chain-specific claim that Cursor Bugbot is "currently enabled on repo" (unverified for this repo).

## Notes

- **`allowed-team` carries over unchanged.** `@sei-protocol/sei-core` is the default owner in this repo's CODEOWNERS, so the same team gate applies.
- **Verified** both reusable workflows exist at the pinned ref and that v0.0.12 is the latest UCI release.
- **Secrets dependency:** both use `secrets: inherit`, so the pipeline relies on org-level secrets (API key / OIDC role) being available to `sei-docs`. If UCI was configured org-wide at `sei-protocol` this works as-is; if it was scoped per-repo on sei-chain, an org admin may need to grant `sei-docs` access.
- Scoped to just these two workflow files; unrelated in-progress changes in the working tree were intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)