### PR TITLE
docs: add prebuilt seid binary install option (node ops + CLI pages)

### DIFF
--- a/evm/installing-seid-cli.mdx
+++ b/evm/installing-seid-cli.mdx
@@ -12,24 +12,50 @@ The `seid` CLI is the command-line tool for interacting with the Sei blockchain.
 
 ## Prerequisites
 
-- Go 1.23+: Installation instructions are available [here](https://go.dev/doc/install).
+- Go 1.23+ (build from source only): Installation instructions are available [here](https://go.dev/doc/install). The prebuilt binary has no prerequisites.
 
 ## Installation
 
-To install seid, locate the version you wish to use on the [sei-chain releases page](https://github.com/sei-protocol/sei-chain/releases). A list of the currently used versions on mainnet and testnet are displayed right below.
+To install `seid`, locate the version you wish to use on the [sei-chain releases page](https://github.com/sei-protocol/sei-chain/releases). A list of the currently used versions on mainnet and testnet are displayed right below.
 
 <VersionTable />
 
-Then, execute the following commands with the version that you picked:
+<Tabs>
+  <Tab title="Prebuilt binary (recommended)">
+    Each release attaches a statically linked `seid` build for `linux/amd64` with no
+    runtime dependencies:
 
-```bash
-git clone https://github.com/sei-protocol/sei-chain
-cd sei-chain
-git checkout [VERSION]
-make install
-```
+    ```bash
+    VERSION=<version-tag>  # e.g. v6.6.0 — see the version table above
+    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
 
-You can verify that seid was installed correctly by running:
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
+
+    # Verify integrity before trusting the binary
+    sha256sum -c checksums.txt --ignore-missing
+
+    tar -xzf ${FILE} seid
+    sudo install -m 0755 seid /usr/local/bin/seid
+    ```
+
+    <Info>
+      Prebuilt binaries are `linux/amd64` only and omit hardware Ledger support. On
+      other architectures, or if you sign with a Ledger device, build from source.
+    </Info>
+  </Tab>
+
+  <Tab title="Build from source">
+    ```bash
+    git clone https://github.com/sei-protocol/sei-chain
+    cd sei-chain
+    git checkout [VERSION]
+    make install
+    ```
+  </Tab>
+</Tabs>
+
+You can verify that `seid` was installed correctly by running:
 
 ```bash
 seid version

--- a/evm/installing-seid-cli.mdx
+++ b/evm/installing-seid-cli.mdx
@@ -32,24 +32,29 @@ To install `seid`, locate the version you wish to use on the [sei-chain releases
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
 
-    # Verify integrity before trusting the binary
-    sha256sum -c checksums.txt --ignore-missing
-
-    tar -xzf ${FILE} seid
-    sudo install -m 0755 seid /usr/local/bin/seid
+    # Verify integrity before trusting the binary; extract and install only if it passes
+    sha256sum -c checksums.txt --ignore-missing \
+      && tar -xzf ${FILE} seid \
+      && sudo install -m 0755 seid /usr/local/bin/seid
     ```
 
     <Info>
       Prebuilt binaries are `linux/amd64` only and omit hardware Ledger support. On
       other architectures, or if you sign with a Ledger device, build from source.
     </Info>
+
+    <Note>
+      Previously installed with `make install`? An older copy in `$(go env GOPATH)/bin`
+      can shadow `/usr/local/bin/seid` depending on your `PATH` order — `which -a seid`
+      lists every copy.
+    </Note>
   </Tab>
 
   <Tab title="Build from source">
     ```bash
     git clone https://github.com/sei-protocol/sei-chain
     cd sei-chain
-    git checkout [VERSION]
+    git checkout <version-tag>
     make install
     ```
   </Tab>
@@ -63,7 +68,7 @@ seid version
 
 ## Troubleshooting Installation
 
-<Warning>If you encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.</Warning>
+<Warning>If you built from source and encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.</Warning>
 
 - Use `go env GOPATH` to find your GOPATH
 - Add the following lines to your `~/.bashrc` or `~/.zshrc`:
@@ -294,8 +299,12 @@ This will remove the specified wallet from your local keyring. Be cautious, as t
 
 ## Uninstalling seid
 
-If you need to remove `seid` from your system, you can delete the binary from your `$GOPATH/bin` directory:
+If you need to remove `seid` from your system, delete the binary from wherever it was installed:
 
 ```bash
+# Prebuilt binary install
+sudo rm /usr/local/bin/seid
+
+# Build-from-source install
 rm $(go env GOPATH)/bin/seid
 ```

--- a/node/index.mdx
+++ b/node/index.mdx
@@ -85,49 +85,83 @@ go version
 </Step>
 
 <Step title="Install Sei">
-##### Install Sei Binary
+##### Install the `seid` binary
 
-```bash
-# Clone repository and install
-git clone https://github.com/sei-protocol/sei-chain.git
-cd sei-chain
-git checkout <version-tag>  # Replace with specific version
-make install
+See the Network Versions table above for the current recommended version.
 
-# Verify installation
-seid version
-```
+<Tabs>
+  <Tab title="Prebuilt binary (recommended)">
+    Each release attaches a statically linked `seid` build for `linux/amd64` with no
+    runtime dependencies: no Go toolchain and no shared libraries to install.
 
-See Network Versions table above for current recommended version.
+    ```bash
+    VERSION=<version-tag>  # e.g. v6.6.0 — see the Network Versions table above
+    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
 
-<Accordion title="Alternative: Docker Image">
-  Official Docker images are available at GitHub Container Registry.
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
 
-  ```bash
-  # Pull the latest version
-  docker pull ghcr.io/sei-protocol/sei:latest
+    # Verify integrity before trusting the binary
+    sha256sum -c checksums.txt --ignore-missing
 
-  # Or pull a specific version (recommended)
-  docker pull ghcr.io/sei-protocol/sei:v6.3.1
-  ```
+    tar -xzf ${FILE} seid
+    sudo install -m 0755 seid /usr/local/bin/seid
 
-  Available architectures: linux/amd64 and linux/arm64.
-</Accordion>
+    # Verify installation
+    seid version --long
+    ```
 
-<Info>
-  If you encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.
+    <Info>
+      Prebuilt binaries are `linux/amd64` only and omit hardware Ledger support. On
+      other architectures, or if you sign with a Ledger device, build from source or
+      use Docker.
+    </Info>
+  </Tab>
 
-  Add the following to your `~/.bashrc` or `~/.zshrc`:
+  <Tab title="Build from source">
+    Requires Go and a C toolchain (see the Environment Setup step above).
 
-  ```bash
-  export GOPATH=$(go env GOPATH)
-  export PATH=$PATH:$GOPATH/bin
-  ```
+    ```bash
+    # Clone repository and install
+    git clone https://github.com/sei-protocol/sei-chain.git
+    cd sei-chain
+    git checkout <version-tag>  # Replace with specific version
+    make install
 
-  Then reload your shell with `source ~/.bashrc` or `source ~/.zshrc`.
+    # Verify installation
+    seid version
+    ```
 
-  For more information see [here](https://pkg.go.dev/cmd/go#hdr-GOPATH_environment_variable).
-</Info>
+    <Info>
+      If you encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.
+
+      Add the following to your `~/.bashrc` or `~/.zshrc`:
+
+      ```bash
+      export GOPATH=$(go env GOPATH)
+      export PATH=$PATH:$GOPATH/bin
+      ```
+
+      Then reload your shell with `source ~/.bashrc` or `source ~/.zshrc`.
+
+      For more information see [here](https://pkg.go.dev/cmd/go#hdr-GOPATH_environment_variable).
+    </Info>
+  </Tab>
+
+  <Tab title="Docker">
+    Official Docker images are available at GitHub Container Registry.
+
+    ```bash
+    # Pull the latest version
+    docker pull ghcr.io/sei-protocol/sei:latest
+
+    # Or pull a specific version (recommended)
+    docker pull ghcr.io/sei-protocol/sei:v6.3.1
+    ```
+
+    Available architectures: linux/amd64 and linux/arm64.
+  </Tab>
+</Tabs>
 
 ##### Initialize Chain Files
 

--- a/node/index.mdx
+++ b/node/index.mdx
@@ -63,6 +63,9 @@ timedatectl
 
 ##### Install Go
 
+Only needed if you build `seid` from source — the prebuilt binary and Docker
+install paths in the next step don't require Go.
+
 Suggested Version: Go 1.24.x (required for seid v6.3+)
 
 ###### Installation Steps
@@ -101,21 +104,27 @@ See the Network Versions table above for the current recommended version.
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
 
-    # Verify integrity before trusting the binary
-    sha256sum -c checksums.txt --ignore-missing
-
-    tar -xzf ${FILE} seid
-    sudo install -m 0755 seid /usr/local/bin/seid
+    # Verify integrity before trusting the binary; extract and install only if it passes
+    sha256sum -c checksums.txt --ignore-missing \
+      && tar -xzf ${FILE} seid \
+      && sudo install -m 0755 seid /usr/local/bin/seid
 
     # Verify installation
-    seid version --long
+    seid version
     ```
 
     <Info>
-      Prebuilt binaries are `linux/amd64` only and omit hardware Ledger support. On
-      other architectures, or if you sign with a Ledger device, build from source or
-      use Docker.
+      Prebuilt binaries are `linux/amd64` only, omit hardware Ledger support, and
+      don't include the optional [RocksDB state-store backend](/node/rocksdb-backend).
+      On other architectures, or if you sign with a Ledger device, build from source
+      or use Docker; a RocksDB-enabled `seid` must be built from source.
     </Info>
+
+    <Note>
+      Switching from a previous `make install` build? Remove the old copy
+      (`rm -f "$(go env GOPATH)/bin/seid"`) or make sure your service unit points at
+      `/usr/local/bin/seid` — `which -a seid` lists every copy on your `PATH`.
+    </Note>
   </Tab>
 
   <Tab title="Build from source">

--- a/node/node-operators.mdx
+++ b/node/node-operators.mdx
@@ -1583,23 +1583,55 @@ EOF
 
 ## Update Procedures
 
+<Info>
+  Upgrade with the same method you originally installed with: `make install`
+  writes `seid` to `$(go env GOPATH)/bin`, while the prebuilt-binary flow
+  installs to `/usr/local/bin`. Mixing the two leaves separate binaries on your
+  `PATH`, and your service unit may keep running the old version —
+  `which -a seid` lists every copy.
+</Info>
+
 ### Minor Updates
 
 For minor updates that are non-consensus-breaking:
 
-```bash
-# Stop node
-sudo systemctl stop seid
+<Tabs>
+  <Tab title="Prebuilt binary">
+    ```bash
+    # Stop node
+    sudo systemctl stop seid
 
-# Update binary
-cd sei-chain
-git fetch --all
-git checkout [new-version]
-make install
+    # Download and verify the new release binary
+    VERSION=<new-version>  # the new release tag, e.g. v6.6.0
+    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
 
-# Restart node
-sudo systemctl restart seid
-```
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
+    sha256sum -c checksums.txt --ignore-missing \
+      && tar -xzf ${FILE} seid \
+      && sudo install -m 0755 seid /usr/local/bin/seid
+
+    # Restart node
+    sudo systemctl restart seid
+    ```
+  </Tab>
+
+  <Tab title="Build from source">
+    ```bash
+    # Stop node
+    sudo systemctl stop seid
+
+    # Update binary
+    cd sei-chain
+    git fetch --all
+    git checkout <new-version>
+    make install
+
+    # Restart node
+    sudo systemctl restart seid
+    ```
+  </Tab>
+</Tabs>
 
 ### Major Updates
 
@@ -1611,18 +1643,38 @@ For major upgrades that introduce state-breaking changes:
 3. Update/replace the binary
 4. Restart the node.
 
-```bash
-# After node halts
-cd sei-chain
-git pull
-git checkout [new-version]
-make install
-sudo systemctl restart seid
-```
+<Tabs>
+  <Tab title="Prebuilt binary">
+    ```bash
+    # After node halts
+    VERSION=<new-version>  # the new release tag, e.g. v6.6.0
+    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz
+
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
+    sha256sum -c checksums.txt --ignore-missing \
+      && tar -xzf ${FILE} seid \
+      && sudo install -m 0755 seid /usr/local/bin/seid
+
+    sudo systemctl restart seid
+    ```
+  </Tab>
+
+  <Tab title="Build from source">
+    ```bash
+    # After node halts
+    cd sei-chain
+    git pull
+    git checkout <new-version>
+    make install
+    sudo systemctl restart seid
+    ```
+  </Tab>
+</Tabs>
 
 <Tip>
-  Build the upgrade before the halt-height so you can quickly replace it
-  with minimal downtime.
+  Download the release archive (or build the new binary) ahead of the
+  halt-height so the swap takes seconds at upgrade time.
 </Tip>
 
 ## Performance Optimization


### PR DESCRIPTION
## What

Adds the **prebuilt release binary** as the recommended `seid` install path on the two install surfaces, presented as tabs alongside the existing build-from-source and Docker options:

* `node/index.mdx` — the Install Sei step in the node setup flow
* `evm/installing-seid-cli.mdx` — the CLI installation guide

The instructions cover download, **sha256 checksum verification**, and install, with callouts for the two caveats: `linux/amd64` only, and no hardware Ledger support (both routed to build-from-source/Docker).

## Why

sei-chain releases attach a statically linked `seid` (built and boot-tested by CI via sei-protocol/sei-chain#3749's pipeline), which removes the Go-toolchain requirement for operators. The docs currently only describe building from source.

## Notes for reviewers

* Asset filenames omit the leading `v` of the version tag (`sei-chain_6.6.0_linux_x86_64.tar.gz` under the `v6.6.0` release); the examples handle this with `${VERSION#v}` so copy-paste works.
* **Merge timing:** hold until the first release that actually carries binaries is out (the next sei-chain tag after sei-protocol/sei-chain#3749 reaches the release branch), so the download commands resolve on day one.
* `mint broken-links` passes.