### PR TITLE
Revert "docs: add prebuilt seid binary install option" (#44)

### DIFF
--- a/evm/installing-seid-cli.mdx
+++ b/evm/installing-seid-cli.mdx
@@ -12,55 +12,24 @@ The `seid` CLI is the command-line tool for interacting with the Sei blockchain.
 
 ## Prerequisites
 
-- Go 1.23+ (build from source only): Installation instructions are available [here](https://go.dev/doc/install). The prebuilt binary has no prerequisites.
+- Go 1.23+: Installation instructions are available [here](https://go.dev/doc/install).
 
 ## Installation
 
-To install `seid`, locate the version you wish to use on the [sei-chain releases page](https://github.com/sei-protocol/sei-chain/releases). A list of the currently used versions on mainnet and testnet are displayed right below.
+To install seid, locate the version you wish to use on the [sei-chain releases page](https://github.com/sei-protocol/sei-chain/releases). A list of the currently used versions on mainnet and testnet are displayed right below.
 
 <VersionTable />
 
-<Tabs>
-  <Tab title="Prebuilt binary (recommended)">
-    Each release attaches a statically linked `seid` build for `linux/amd64` with no
-    runtime dependencies:
+Then, execute the following commands with the version that you picked:
 
-    ```bash
-    VERSION=<version-tag>  # e.g. v6.6.0 — see the version table above
-    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
+```bash
+git clone https://github.com/sei-protocol/sei-chain
+cd sei-chain
+git checkout [VERSION]
+make install
+```
 
-    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
-    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
-
-    # Verify integrity before trusting the binary; extract and install only if it passes
-    sha256sum -c checksums.txt --ignore-missing \
-      && tar -xzf ${FILE} seid \
-      && sudo install -m 0755 seid /usr/local/bin/seid
-    ```
-
-    <Info>
-      Prebuilt binaries are `linux/amd64` only and omit hardware Ledger support. On
-      other architectures, or if you sign with a Ledger device, build from source.
-    </Info>
-
-    <Note>
-      Previously installed with `make install`? An older copy in `$(go env GOPATH)/bin`
-      can shadow `/usr/local/bin/seid` depending on your `PATH` order — `which -a seid`
-      lists every copy.
-    </Note>
-  </Tab>
-
-  <Tab title="Build from source">
-    ```bash
-    git clone https://github.com/sei-protocol/sei-chain
-    cd sei-chain
-    git checkout <version-tag>
-    make install
-    ```
-  </Tab>
-</Tabs>
-
-You can verify that `seid` was installed correctly by running:
+You can verify that seid was installed correctly by running:
 
 ```bash
 seid version
@@ -68,7 +37,7 @@ seid version
 
 ## Troubleshooting Installation
 
-<Warning>If you built from source and encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.</Warning>
+<Warning>If you encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.</Warning>
 
 - Use `go env GOPATH` to find your GOPATH
 - Add the following lines to your `~/.bashrc` or `~/.zshrc`:
@@ -299,12 +268,8 @@ This will remove the specified wallet from your local keyring. Be cautious, as t
 
 ## Uninstalling seid
 
-If you need to remove `seid` from your system, delete the binary from wherever it was installed:
+If you need to remove `seid` from your system, you can delete the binary from your `$GOPATH/bin` directory:
 
 ```bash
-# Prebuilt binary install
-sudo rm /usr/local/bin/seid
-
-# Build-from-source install
 rm $(go env GOPATH)/bin/seid
 ```

--- a/node/index.mdx
+++ b/node/index.mdx
@@ -63,9 +63,6 @@ timedatectl
 
 ##### Install Go
 
-Only needed if you build `seid` from source — the prebuilt binary and Docker
-install paths in the next step don't require Go.
-
 Suggested Version: Go 1.24.x (required for seid v6.3+)
 
 ###### Installation Steps
@@ -88,89 +85,49 @@ go version
 </Step>
 
 <Step title="Install Sei">
-##### Install the `seid` binary
+##### Install Sei Binary
 
-See the Network Versions table above for the current recommended version.
+```bash
+# Clone repository and install
+git clone https://github.com/sei-protocol/sei-chain.git
+cd sei-chain
+git checkout <version-tag>  # Replace with specific version
+make install
 
-<Tabs>
-  <Tab title="Prebuilt binary (recommended)">
-    Each release attaches a statically linked `seid` build for `linux/amd64` with no
-    runtime dependencies: no Go toolchain and no shared libraries to install.
+# Verify installation
+seid version
+```
 
-    ```bash
-    VERSION=<version-tag>  # e.g. v6.6.0 — see the Network Versions table above
-    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
+See Network Versions table above for current recommended version.
 
-    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
-    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
+<Accordion title="Alternative: Docker Image">
+  Official Docker images are available at GitHub Container Registry.
 
-    # Verify integrity before trusting the binary; extract and install only if it passes
-    sha256sum -c checksums.txt --ignore-missing \
-      && tar -xzf ${FILE} seid \
-      && sudo install -m 0755 seid /usr/local/bin/seid
+  ```bash
+  # Pull the latest version
+  docker pull ghcr.io/sei-protocol/sei:latest
 
-    # Verify installation
-    seid version
-    ```
+  # Or pull a specific version (recommended)
+  docker pull ghcr.io/sei-protocol/sei:v6.3.1
+  ```
 
-    <Info>
-      Prebuilt binaries are `linux/amd64` only, omit hardware Ledger support, and
-      don't include the optional [RocksDB state-store backend](/node/rocksdb-backend).
-      On other architectures, or if you sign with a Ledger device, build from source
-      or use Docker; a RocksDB-enabled `seid` must be built from source.
-    </Info>
+  Available architectures: linux/amd64 and linux/arm64.
+</Accordion>
 
-    <Note>
-      Switching from a previous `make install` build? Remove the old copy
-      (`rm -f "$(go env GOPATH)/bin/seid"`) or make sure your service unit points at
-      `/usr/local/bin/seid` — `which -a seid` lists every copy on your `PATH`.
-    </Note>
-  </Tab>
+<Info>
+  If you encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.
 
-  <Tab title="Build from source">
-    Requires Go and a C toolchain (see the Environment Setup step above).
+  Add the following to your `~/.bashrc` or `~/.zshrc`:
 
-    ```bash
-    # Clone repository and install
-    git clone https://github.com/sei-protocol/sei-chain.git
-    cd sei-chain
-    git checkout <version-tag>  # Replace with specific version
-    make install
+  ```bash
+  export GOPATH=$(go env GOPATH)
+  export PATH=$PATH:$GOPATH/bin
+  ```
 
-    # Verify installation
-    seid version
-    ```
+  Then reload your shell with `source ~/.bashrc` or `source ~/.zshrc`.
 
-    <Info>
-      If you encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.
-
-      Add the following to your `~/.bashrc` or `~/.zshrc`:
-
-      ```bash
-      export GOPATH=$(go env GOPATH)
-      export PATH=$PATH:$GOPATH/bin
-      ```
-
-      Then reload your shell with `source ~/.bashrc` or `source ~/.zshrc`.
-
-      For more information see [here](https://pkg.go.dev/cmd/go#hdr-GOPATH_environment_variable).
-    </Info>
-  </Tab>
-
-  <Tab title="Docker">
-    Official Docker images are available at GitHub Container Registry.
-
-    ```bash
-    # Pull the latest version
-    docker pull ghcr.io/sei-protocol/sei:latest
-
-    # Or pull a specific version (recommended)
-    docker pull ghcr.io/sei-protocol/sei:v6.3.1
-    ```
-
-    Available architectures: linux/amd64 and linux/arm64.
-  </Tab>
-</Tabs>
+  For more information see [here](https://pkg.go.dev/cmd/go#hdr-GOPATH_environment_variable).
+</Info>
 
 ##### Initialize Chain Files
 

--- a/node/node-operators.mdx
+++ b/node/node-operators.mdx
@@ -1583,55 +1583,23 @@ EOF
 
 ## Update Procedures
 
-<Info>
-  Upgrade with the same method you originally installed with: `make install`
-  writes `seid` to `$(go env GOPATH)/bin`, while the prebuilt-binary flow
-  installs to `/usr/local/bin`. Mixing the two leaves separate binaries on your
-  `PATH`, and your service unit may keep running the old version —
-  `which -a seid` lists every copy.
-</Info>
-
 ### Minor Updates
 
 For minor updates that are non-consensus-breaking:
 
-<Tabs>
-  <Tab title="Prebuilt binary">
-    ```bash
-    # Stop node
-    sudo systemctl stop seid
+```bash
+# Stop node
+sudo systemctl stop seid
 
-    # Download and verify the new release binary
-    VERSION=<new-version>  # the new release tag, e.g. v6.6.0
-    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
+# Update binary
+cd sei-chain
+git fetch --all
+git checkout [new-version]
+make install
 
-    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
-    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
-    sha256sum -c checksums.txt --ignore-missing \
-      && tar -xzf ${FILE} seid \
-      && sudo install -m 0755 seid /usr/local/bin/seid
-
-    # Restart node
-    sudo systemctl restart seid
-    ```
-  </Tab>
-
-  <Tab title="Build from source">
-    ```bash
-    # Stop node
-    sudo systemctl stop seid
-
-    # Update binary
-    cd sei-chain
-    git fetch --all
-    git checkout <new-version>
-    make install
-
-    # Restart node
-    sudo systemctl restart seid
-    ```
-  </Tab>
-</Tabs>
+# Restart node
+sudo systemctl restart seid
+```
 
 ### Major Updates
 
@@ -1643,38 +1611,18 @@ For major upgrades that introduce state-breaking changes:
 3. Update/replace the binary
 4. Restart the node.
 
-<Tabs>
-  <Tab title="Prebuilt binary">
-    ```bash
-    # After node halts
-    VERSION=<new-version>  # the new release tag, e.g. v6.6.0
-    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz
-
-    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
-    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
-    sha256sum -c checksums.txt --ignore-missing \
-      && tar -xzf ${FILE} seid \
-      && sudo install -m 0755 seid /usr/local/bin/seid
-
-    sudo systemctl restart seid
-    ```
-  </Tab>
-
-  <Tab title="Build from source">
-    ```bash
-    # After node halts
-    cd sei-chain
-    git pull
-    git checkout <new-version>
-    make install
-    sudo systemctl restart seid
-    ```
-  </Tab>
-</Tabs>
+```bash
+# After node halts
+cd sei-chain
+git pull
+git checkout [new-version]
+make install
+sudo systemctl restart seid
+```
 
 <Tip>
-  Download the release archive (or build the new binary) ahead of the
-  halt-height so the swap takes seconds at upgrade time.
+  Build the upgrade before the halt-height so you can quickly replace it
+  with minimal downtime.
 </Tip>
 
 ## Performance Optimization


### PR DESCRIPTION
## What

Reverts #44 (merge commit `c7fa1f4`), which added the prebuilt release binary as the recommended `seid` install path. Restores three pages to their pre-#44 state:

- `evm/installing-seid-cli.mdx`
- `node/index.mdx`
- `node/node-operators.mdx`

Verified: the reverted tree is byte-identical to the pre-merge version of each file, and no `prebuilt` references remain.

## Why

The prebuilt binaries aren't attached to a published sei-chain release yet. #44's own merge-timing note said to **hold until the first release carrying binaries ships** — it landed ahead of that, so the download + `sha256sum` verification commands would 404 for readers today.

## Re-applying later (keep ready)

This is a **temporary** revert. When the first release with binaries is out, bring the docs back by **reverting this PR** — the GitHub **Revert** button on this PR, or `git revert -m 1 <this PR's merge commit>`. That cleanly restores all of #44's content.

> Note: a plain re-merge of the old branch won't reintroduce the content, since those commits are already in `main`'s history — reverting the revert is the correct path.

The original branch [`docs/prebuilt-seid-binaries`](https://github.com/sei-protocol/sei-docs/tree/docs/prebuilt-seid-binaries) is preserved on the remote as a reference snapshot of the intended final content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
