### PR TITLE
chore: remove unused code from snippets, script, and styles

### DIFF
--- a/scripts/sync-default-configs.mjs
+++ b/scripts/sync-default-configs.mjs
@@ -23,7 +23,6 @@
  * top level and will fail to parse the page.
  */
 
-import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';

--- a/snippets/ecosystem-contracts.jsx
+++ b/snippets/ecosystem-contracts.jsx
@@ -685,11 +685,6 @@ export const EcosystemContracts = () => {
 	}, [pendingScrollId]);
 
 	// --- Theme-aware brand colors (replace former sei-* Tailwind classes) ---
-	// Light/dark text + background for the SeiScan link button.
-	const seiScanStyle = isDark
-		? { color: 'var(--sei-maroon-25)', backgroundColor: 'rgba(96, 0, 20, 0.2)' }
-		: { color: 'var(--sei-maroon-100)', backgroundColor: 'var(--sei-grey-25)' };
-
 	const focusRingColor = 'var(--sei-maroon-100)';
 
 	// Desktop rows use a div-based grid (not a <table>): Mintlify maps MDX

--- a/style.css
+++ b/style.css
@@ -1217,38 +1217,6 @@ figure {
 }
 
 /* --------------------------------------------------------------------------
-   Utilities for custom MDX (if authors want a Sei-branded eyebrow or square)
-   -------------------------------------------------------------------------- */
-
-.sei-icon-square {
-  width: 20px;
-  height: 20px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--sei-maroon-100);
-  color: var(--sei-white);
-  border-radius: var(--sei-radius-sm);
-  flex-shrink: 0;
-}
-
-.sei-icon-square.gold {
-  background: var(--sei-gold-100);
-}
-
-.sei-meta {
-  font-family: var(--sei-font-mono);
-  text-transform: uppercase;
-  font-size: 11px;
-  letter-spacing: 0.04em;
-  color: var(--sei-gold-100);
-}
-
-.dark .sei-meta {
-  color: var(--sei-gold-25);
-}
-
-/* --------------------------------------------------------------------------
    Widget iframes — let height be content-driven, not 16/9 cinematic crop
    --------------------------------------------------------------------------
    Mintlify's OptimizedFrame wrapper auto-applies `aspect-ratio: 16 / 9` to


### PR DESCRIPTION
## What is the purpose of the change?

Housekeeping — deletes stale/dead code (unused variables, an unused import, and unreferenced CSS utilities) to streamline the codebase. No documentation content, rendering, or runtime behavior changes.

## Describe the changes to the documentation

This is a pure dead-code cleanup across the repo's non-content code surfaces. Each removal was verified to have zero usages before deletion:

- **`scripts/sync-default-configs.mjs`** — dropped the unused `import { execSync }`. It was the only import from `node:child_process`; the script only reads/writes files and never spawns a process.
- **`snippets/ecosystem-contracts.jsx`** — removed the `seiScanStyle` variable. It was declared but never read; the SeiScan link button builds its own style object.
- **`style.css`** — removed the unused custom MDX author utilities `.sei-icon-square` (+ `.gold` modifier) and `.sei-meta` (+ `.dark` variant). These had zero references in any `.mdx`, snippet, or `docs.json`.

Deliberately **kept**:
- `.sei-eyebrow` — its rule is shared with the `[class*="eyebrow"]` attribute selector, so it can't be removed cleanly.
- `.sei-eco-grid` — actually in use by `snippets/ecosystem-app-grid.jsx`.

## Notes

- **Net:** 3 files changed, 38 deletions, 0 additions.
- **Verification:** all 11 snippet `.jsx` files validated with esbuild, all `.mjs`/`.js` with `node --check`, and `style.css` parses with balanced braces (136/136) — before and after the changes.
- A broader sweep of the other 13 JS files (including the large `rpc-methods-viewer.jsx` and `changelog.jsx`) found no further dead code; the codebase was already well-maintained.
- No tracked `package.json` exists (Mintlify manages deps), so there were no unused packages to prune.
- `llms-full.txt` still references `seiScanStyle`, but that file is a generated artifact sourced from the live `docs.sei.io` `.md` endpoints — it refreshes on its normal post-deploy regeneration cycle, not from local source, so it is intentionally left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)