### PR TITLE
docs: replace Mintscan explorer links with Seistream

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -66,7 +66,7 @@ The EVM section is the primary developer resource for building on Sei. It covers
 
 ### Cosmos-SDK (Deprecated)
 
-> ⚠️ **Deprecation Notice**: Cosmos SDK and CosmWasm functionality is being deprecated in favor of EVM-only. For more details, see [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md) and [Proposal 99](https://www.mintscan.io/sei/proposals/99).
+> ⚠️ **Deprecation Notice**: Cosmos SDK and CosmWasm functionality is being deprecated in favor of EVM-only. For more details, see [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md) and [Proposal 99](https://seistream.app/proposals/99).
 
 This section contains legacy documentation for Cosmos SDK functionality. New development should focus on the EVM.
 

--- a/cosmos-sdk/index.mdx
+++ b/cosmos-sdk/index.mdx
@@ -10,10 +10,10 @@ canonicalUrl: "https://docs.sei.io/evm"
 
 **Deprecation Notice**
 
-Cosmos SDK and CosmWasm functionality is being deprecated in favor of EVM-only. For more details, see [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md) and [Proposal 99](https://www.mintscan.io/sei/proposals/99).
+Cosmos SDK and CosmWasm functionality is being deprecated in favor of EVM-only. For more details, see [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md) and [Proposal 99](https://seistream.app/proposals/99).
 
-In addition, [Proposal 115](https://www.mintscan.io/sei/proposals/115) disables CosmWasm code uploads (`MsgStoreCode`) and contract instantiations (`MsgInstantiateContract`) chain-wide. No new CosmWasm contracts can be deployed; only `execute` and `query` against pre-existing contracts remain available via the [CosmWasm precompile](/evm/precompiles/cosmwasm-precompiles/cosmwasm).
+In addition, [Proposal 115](https://seistream.app/proposals/115) disables CosmWasm code uploads (`MsgStoreCode`) and contract instantiations (`MsgInstantiateContract`) chain-wide. No new CosmWasm contracts can be deployed; only `execute` and `query` against pre-existing contracts remain available via the [CosmWasm precompile](/evm/precompiles/cosmwasm-precompiles/cosmwasm).
 
-[Proposal 116](https://www.mintscan.io/sei/proposals/116) additionally disables inbound IBC transfers. After this passes and is activated, IBC assets bridged from Cosmos chains can no longer arrive on Sei. [Proposal 120](https://www.mintscan.io/sei/proposals/120) re-disables inbound IBC (setting the `ibc` module's `InboundEnabled` parameter to `false`) while leaving outbound IBC unchanged. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for affected assets and migration routes.
+[Proposal 116](https://seistream.app/proposals/116) additionally disables inbound IBC transfers. After this passes and is activated, IBC assets bridged from Cosmos chains can no longer arrive on Sei. [Proposal 120](https://seistream.app/proposals/120) re-disables inbound IBC (setting the `ibc` module's `InboundEnabled` parameter to `false`) while leaving outbound IBC unchanged. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for affected assets and migration routes.
 
 </Danger>

--- a/docs.json
+++ b/docs.json
@@ -461,8 +461,8 @@
             "href": "https://seiscan.io"
           },
           {
-            "label": "Mintscan",
-            "href": "https://www.mintscan.io/sei"
+            "label": "Seistream",
+            "href": "https://seistream.app"
           }
         ]
       },

--- a/evm/differences-with-ethereum.mdx
+++ b/evm/differences-with-ethereum.mdx
@@ -35,11 +35,11 @@ Sei's EVM and Ethereum itself:
 
 **Deprecation Notice**
 
-Cosmos SDK and CosmWasm functionality is being deprecated in favor of EVM-only. For more details, see [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md) and [Proposal 99](https://www.mintscan.io/sei/proposals/99).
+Cosmos SDK and CosmWasm functionality is being deprecated in favor of EVM-only. For more details, see [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md) and [Proposal 99](https://seistream.app/proposals/99).
 
-[Proposal 115](https://www.mintscan.io/sei/proposals/115) further disables CosmWasm code uploads and contract instantiations chain-wide — no new CosmWasm contracts can be deployed. Only `execute` and `query` against pre-existing CosmWasm contracts remain available.
+[Proposal 115](https://seistream.app/proposals/115) further disables CosmWasm code uploads and contract instantiations chain-wide — no new CosmWasm contracts can be deployed. Only `execute` and `query` against pre-existing CosmWasm contracts remain available.
 
-[Proposal 116](https://www.mintscan.io/sei/proposals/116) additionally disables inbound IBC transfers — IBC assets bridged from Cosmos chains can no longer arrive on Sei after this passes and is activated. [Proposal 120](https://www.mintscan.io/sei/proposals/120) re-disables inbound IBC (setting the `ibc` module's `InboundEnabled` parameter to `false`) while leaving outbound IBC unchanged. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for affected assets and migration routes.
+[Proposal 116](https://seistream.app/proposals/116) additionally disables inbound IBC transfers — IBC assets bridged from Cosmos chains can no longer arrive on Sei after this passes and is activated. [Proposal 120](https://seistream.app/proposals/120) re-disables inbound IBC (setting the `ibc` module's `InboundEnabled` parameter to `false`) while leaving outbound IBC unchanged. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for affected assets and migration routes.
 
 </Danger>
 
@@ -182,7 +182,7 @@ Transaction Fee = Gas Used × Gas Price
 
 On Sei, the `SSTORE` opcode gas cost is configurable as an on-chain parameter, meaning it can be adjusted via governance proposal without requiring a chain upgrade. This provides flexibility to tune storage costs based on EVM state size and network conditions.
 
-Currently, the `SSTORE` gas cost is set to the non-standard value of **72,000 gas**. This value is the same on both mainnet (`pacific-1`) and testnet (`atlantic-2`). It was set by governance [Proposal #109](https://www.mintscan.io/sei/proposals/109) ("Update EVM SSTORE set gas to 72000"), which changed the `evm` module parameter `KeySeiSstoreSetGasEIP2200` to `72000`.
+Currently, the `SSTORE` gas cost is set to the non-standard value of **72,000 gas**. This value is the same on both mainnet (`pacific-1`) and testnet (`atlantic-2`). It was set by governance [Proposal #109](https://seistream.app/proposals/109) ("Update EVM SSTORE set gas to 72000"), which changed the `evm` module parameter `KeySeiSstoreSetGasEIP2200` to `72000`.
 
 The values below are read **live** from the Sei EVM: 
 

--- a/evm/precompiles/cosmwasm-precompiles/cosmwasm.mdx
+++ b/evm/precompiles/cosmwasm-precompiles/cosmwasm.mdx
@@ -9,9 +9,9 @@ keywords: ['cosmwasm precompile', 'ethers.js', 'wasm execution', 'cross-chain co
 <Danger>
   **Deprecation Notice — Prop 115 & Prop 116**
 
-  Per [governance Proposal 115](https://www.mintscan.io/sei/proposals/115), CosmWasm code uploads (`MsgStoreCode`) and contract instantiations (`MsgInstantiateContract`) are disabled chain-wide. The `instantiate()` function on this precompile **will revert** for all callers. Only `execute()`, `execute_batch()`, and `query()` against pre-existing CosmWasm contracts remain functional, and all CosmWasm functionality is deprecated in favor of EVM-only per [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md).
+  Per [governance Proposal 115](https://seistream.app/proposals/115), CosmWasm code uploads (`MsgStoreCode`) and contract instantiations (`MsgInstantiateContract`) are disabled chain-wide. The `instantiate()` function on this precompile **will revert** for all callers. Only `execute()`, `execute_batch()`, and `query()` against pre-existing CosmWasm contracts remain functional, and all CosmWasm functionality is deprecated in favor of EVM-only per [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md).
 
-  In addition, [Proposal 116](https://www.mintscan.io/sei/proposals/116) disables inbound IBC transfers — IBC assets bridged from Cosmos chains can no longer arrive on Sei after this passes and is activated. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for affected assets and migration routes.
+  In addition, [Proposal 116](https://seistream.app/proposals/116) disables inbound IBC transfers — IBC assets bridged from Cosmos chains can no longer arrive on Sei after this passes and is activated. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for affected assets and migration routes.
 
   For new smart contract development, use the EVM directly. See [Deploy a Smart Contract](/evm/evm-general).
 </Danger>
@@ -43,7 +43,7 @@ The CosmWasm precompile exposes the following functions:
 
 ### Transaction Functions
 
-<Warning>The `instantiate()` function has been disabled by [Prop 115](https://www.mintscan.io/sei/proposals/115) and will revert. It is omitted from this reference. The ABI in `@sei-js/precompiles` may still expose it for backwards compatibility, but calling it on-chain will fail.</Warning>
+<Warning>The `instantiate()` function has been disabled by [Prop 115](https://seistream.app/proposals/115) and will revert. It is omitted from this reference. The ABI in `@sei-js/precompiles` may still expose it for backwards compatibility, but calling it on-chain will fail.</Warning>
 
 ```solidity
 /// Executes some message on a CosmWasm contract.

--- a/evm/precompiles/cosmwasm-precompiles/example-usage.mdx
+++ b/evm/precompiles/cosmwasm-precompiles/example-usage.mdx
@@ -6,7 +6,7 @@ keywords: ["precompile example", "ethers.js", "cosmwasm query", "evm integration
 
 
 <Info>
-Per [Proposal 115](https://www.mintscan.io/sei/proposals/115), no new CosmWasm contracts can be deployed on Sei. The examples below apply to **pre-existing CosmWasm contracts** only — `instantiate()` will revert. Separately, [Proposal 116](https://www.mintscan.io/sei/proposals/116) disables inbound IBC transfers as part of the [SIP-03](/learn/sip-03-migration) migration.
+Per [Proposal 115](https://seistream.app/proposals/115), no new CosmWasm contracts can be deployed on Sei. The examples below apply to **pre-existing CosmWasm contracts** only — `instantiate()` will revert. Separately, [Proposal 116](https://seistream.app/proposals/116) disables inbound IBC transfers as part of the [SIP-03](/learn/sip-03-migration) migration.
 </Info>
 
 The Sei precompiles can be used like any standard smart contract on the EVM. For

--- a/learn/dev-interoperability.mdx
+++ b/learn/dev-interoperability.mdx
@@ -6,7 +6,7 @@ keywords: ['blockchain interoperability', 'EVM Cosmos bridge', 'dual address sys
 ---
 
 <Info>
-  **CosmWasm deployments are frozen, and inbound IBC is being disabled.** Per [Proposal 115](https://www.mintscan.io/sei/proposals/115), no new CosmWasm contracts can be uploaded or instantiated on Sei. [Proposal 116](https://www.mintscan.io/sei/proposals/116) additionally disables inbound IBC transfers, so IBC assets bridged from Cosmos chains can no longer arrive on Sei. The interoperability features described on this page apply to **already-deployed** CosmWasm contracts, native Bank Module assets, and Cosmos-SDK modules accessed via precompiles. For new smart contract development, build directly on the EVM. See [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md) for the full migration context.
+  **CosmWasm deployments are frozen, and inbound IBC is being disabled.** Per [Proposal 115](https://seistream.app/proposals/115), no new CosmWasm contracts can be uploaded or instantiated on Sei. [Proposal 116](https://seistream.app/proposals/116) additionally disables inbound IBC transfers, so IBC assets bridged from Cosmos chains can no longer arrive on Sei. The interoperability features described on this page apply to **already-deployed** CosmWasm contracts, native Bank Module assets, and Cosmos-SDK modules accessed via precompiles. For new smart contract development, build directly on the EVM. See [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md) for the full migration context.
 </Info>
 
 ## Dual Address Support

--- a/learn/dev-token-standards.mdx
+++ b/learn/dev-token-standards.mdx
@@ -5,7 +5,7 @@ keywords: ['token standards', 'erc20', 'cw20', 'nfts']
 ---
 
 <Info>
-  **Use ERC20 / ERC721 / ERC1155 for new tokens.** Per [Proposal 115](https://www.mintscan.io/sei/proposals/115), CosmWasm code uploads and contract instantiations are disabled on Sei, so no new CW20 / CW721 / CW1155 tokens can be deployed. The CW standards described below are documented for users and developers interacting with already-deployed legacy contracts.
+  **Use ERC20 / ERC721 / ERC1155 for new tokens.** Per [Proposal 115](https://seistream.app/proposals/115), CosmWasm code uploads and contract instantiations are disabled on Sei, so no new CW20 / CW721 / CW1155 tokens can be deployed. The CW standards described below are documented for users and developers interacting with already-deployed legacy contracts.
 </Info>
 
 In this section, we delve into the various token standards supported on Sei.
@@ -54,7 +54,7 @@ are not unique. Sei supports both ERC20 and CW20 fungible token standards.
   approved, and queried using standard functions. **Use ERC20 for any new
   fungible token on Sei.**
 - **CW20** (legacy only): The Cosmos-side fungible token standard. Per
-  [Prop 115](https://www.mintscan.io/sei/proposals/115), no new CW20 contracts
+  [Prop 115](https://seistream.app/proposals/115), no new CW20 contracts
   can be deployed. Existing CW20 tokens continue to function and can still have
   pointer contracts created for them.
 - **Interoperability and Pointer Contracts**:
@@ -78,7 +78,7 @@ standards for new NFT collections, along with legacy CW721 / CW1155 contracts.
   semi-fungible tokens. **Use these for any new NFT collection on Sei.**
 - **ERC2981**: Defines a royalty mechanism for NFTs, ensuring creators receive
   a percentage of sales.
-- **CW721 / CW1155** (legacy only): Per [Prop 115](https://www.mintscan.io/sei/proposals/115),
+- **CW721 / CW1155** (legacy only): Per [Prop 115](https://seistream.app/proposals/115),
   no new CW721 / CW1155 contracts can be deployed. Existing collections continue
   to function and can be surfaced on the EVM via pointer contracts.
 - **Interoperability**: Similar to fungible tokens, legacy CW NFT collections

--- a/learn/explorers.mdx
+++ b/learn/explorers.mdx
@@ -41,7 +41,6 @@ with the network including:
 <Tabs>
   <Tab title="mainnet (pacific-1)">
     - [Seiscan](https://seiscan.io) — A user-friendly block explorer for the Sei Pacific-1 mainnet.
-    - [Mintscan](https://www.mintscan.io/sei) — Comprehensive blockchain explorer and analytics platform for Sei mainnet.
     - [Seistream](https://seistream.app/) — Real-time transaction streaming and monitoring tool for Sei mainnet.
     - [NG Explorer](https://sei.explorers.guru) — Comprehensive blockchain explorer provided by Nodes Guru for Sei mainnet.
   </Tab>

--- a/learn/pointers.mdx
+++ b/learn/pointers.mdx
@@ -6,7 +6,7 @@ keywords: ['pointer contracts', 'cross-vm interoperability', 'evm cosmos bridge'
 ---
 
 <Info>
-  **Pointer contracts are now primarily a legacy / migration tool.** Per [Proposal 115](https://www.mintscan.io/sei/proposals/115), no new CosmWasm contracts can be uploaded or instantiated on Sei, so the CW20 / CW721 / CW1155 → ERC20 / ERC721 / ERC1155 pointer flow only applies to already-deployed CosmWasm contracts. Native (Bank Module) pointers continue to work normally. For new tokens or NFTs, deploy ERC20 / ERC721 / ERC1155 contracts directly on the EVM.
+  **Pointer contracts are now primarily a legacy / migration tool.** Per [Proposal 115](https://seistream.app/proposals/115), no new CosmWasm contracts can be uploaded or instantiated on Sei, so the CW20 / CW721 / CW1155 → ERC20 / ERC721 / ERC1155 pointer flow only applies to already-deployed CosmWasm contracts. Native (Bank Module) pointers continue to work normally. For new tokens or NFTs, deploy ERC20 / ERC721 / ERC1155 contracts directly on the EVM.
 </Info>
 
 Pointer Contracts enable tokens to be used interoperably in both EVM and

--- a/learn/sip-03-migration.mdx
+++ b/learn/sip-03-migration.mdx
@@ -8,7 +8,7 @@ keywords: ['SIP-03', 'migration', 'asset transfer', 'USDC on Sei', 'Keplr', 'Lea
 
 **Action required: IBC assets on Sei will become inaccessible**
 
-If you hold [USDC.n](https://seiscan.io/address/0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) (USDC via Noble), [USDT.kava](https://seiscan.io/address/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) (Kava USDT), Wormhole-bridged tokens, or any other IBC asset on Sei, you **must** swap, migrate, or bridge out **before [Proposal #116](https://www.mintscan.io/sei/proposals/116) (disables inbound IBC transfers) passes and is activated** to avoid permanent loss of access. After this, Sei will no longer support IBC bridging of assets from Cosmos-based chains to and from Sei Network.
+If you hold [USDC.n](https://seiscan.io/address/0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) (USDC via Noble), [USDT.kava](https://seiscan.io/address/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) (Kava USDT), Wormhole-bridged tokens, or any other IBC asset on Sei, you **must** swap, migrate, or bridge out **before [Proposal #116](https://seistream.app/proposals/116) (disables inbound IBC transfers) passes and is activated** to avoid permanent loss of access. After this, Sei will no longer support IBC bridging of assets from Cosmos-based chains to and from Sei Network.
 
 Consult the [IBC Asset Migration Table](#ibc-asset-migration-table) below for the full list of affected assets, required actions, and supported routes.
 
@@ -24,13 +24,13 @@ For the full proposal text, see:
 
 - The [official SIP-03](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md)
 
-- Governance [Proposal #99](https://www.mintscan.io/sei/proposals/99) — initiated the migration
+- Governance [Proposal #99](https://seistream.app/proposals/99) — initiated the migration
 
-- Governance [Proposal #115](https://www.mintscan.io/sei/proposals/115) — disables CosmWasm code uploads and contract instantiations. After this passes, no new CosmWasm contracts can be deployed on Sei.
+- Governance [Proposal #115](https://seistream.app/proposals/115) — disables CosmWasm code uploads and contract instantiations. After this passes, no new CosmWasm contracts can be deployed on Sei.
 
-- Governance [Proposal #116](https://www.mintscan.io/sei/proposals/116) — disables inbound IBC transfers. After this passes and is activated, IBC assets bridged from Cosmos chains can no longer arrive on Sei.
+- Governance [Proposal #116](https://seistream.app/proposals/116) — disables inbound IBC transfers. After this passes and is activated, IBC assets bridged from Cosmos chains can no longer arrive on Sei.
 
-- Governance [Proposal #120](https://www.mintscan.io/sei/proposals/120) — re-disables inbound IBC transfers by setting the `ibc` module's `InboundEnabled` parameter to `false`, leaving outbound IBC unchanged. Follows up on Proposal #116.
+- Governance [Proposal #120](https://seistream.app/proposals/120) — re-disables inbound IBC transfers by setting the `ibc` module's `InboundEnabled` parameter to `false`, leaving outbound IBC unchanged. Follows up on Proposal #116.
 
 </Info>
 
@@ -41,21 +41,21 @@ For the full proposal text, see:
 
 ## IBC Asset Migration Table
 
-If you hold any of the following IBC assets on Sei, take action before [Proposal #116](https://www.mintscan.io/sei/proposals/116) (disables inbound IBC transfers) passes and is activated.
+If you hold any of the following IBC assets on Sei, take action before [Proposal #116](https://seistream.app/proposals/116) (disables inbound IBC transfers) passes and is activated.
 
 \[We’ll update this table as more resources are made available\]
 
 | Asset | Token contract | Action(s) | Possible route(s) | Support |
 | :---- | :---- | :---- | :---- | :---- |
-| **USDC.n (USDC via Noble)** | [seiscan](https://seiscan.io/address/0x3894085ef7ff0f0aedf52e2a2704928d1ec074f1) [mintscan](https://www.mintscan.io/sei/assets/ibc%2FCA6FBFAF399474A06263E10D0CE5AEBBE15189D6D4B2DD9ADE61007E68EB9DB0) | Swap to native USDC or migrate via CCTP | [Saphyre](https://saphyre.xyz/swap?inputCurrency=0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1&outputCurrency=0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392), [Symphony](https://symph.ag/), or [CCTP Exchange](https://cctp.exchange/) | [Sei blog](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/) [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei?ref=blog.sei.io) |
-| **USDT.kava (USDT via Kava)** | [seiscan](https://seiscan.io/token/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) [mintscan](https://www.mintscan.io/sei/assets/ibc%2F6C00E4AA0CC7618370F81F7378638AE6C48EFF8C9203CE1C2357012B440EBDB7)| Swap to a native asset via Symphony | [Symphony](https://symph.ag/) | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
-| **USDCso (Wormhole, Solana)** | [mintscan](https://www.mintscan.io/sei/assets/factory%2Fsei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l%2F9fELvUhFo6yWL34ZaLgPbCPzdk9MD1tAzMycgH45qShH) | Bridge out to Solana | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) [Discord](https://discord.com/invite/sei) |
+| **USDC.n (USDC via Noble)** | [seiscan](https://seiscan.io/address/0x3894085ef7ff0f0aedf52e2a2704928d1ec074f1) [seistream](https://seistream.app/address/0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) | Swap to native USDC or migrate via CCTP | [Saphyre](https://saphyre.xyz/swap?inputCurrency=0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1&outputCurrency=0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392), [Symphony](https://symph.ag/), or [CCTP Exchange](https://cctp.exchange/) | [Sei blog](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/) [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei?ref=blog.sei.io) |
+| **USDT.kava (USDT via Kava)** | [seiscan](https://seiscan.io/token/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) [seistream](https://seistream.app/address/0xB75D0B03c06A926e488e2659DF1A861F860bD3d1)| Swap to a native asset via Symphony | [Symphony](https://symph.ag/) | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
+| **USDCso (Wormhole, Solana)** | [seistream](https://seistream.app/address/0x8eEDF32a4FC6fB78DDF231Cd3CcF6b7B8dF9D99d) | Bridge out to Solana | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) [Discord](https://discord.com/invite/sei) |
 | **Wormhole-bridged WETH** | [mintscan](https://www.mintscan.io/sei/assets/factory%2Fsei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l%2F4tLQqCLaoKKfNFuPjA9o39YbKUwhR1F8N29Tz3hEbfP2) | Bridge out to Ethereum | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
-| **USDCet (Wormhole, Ethereum)** | [mintscan](https://www.mintscan.io/sei/assets/factory%2Fsei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l%2FHq4tuDzhRBnxw3tFA5n6M52NVMVcC19XggbyDiJKCD6H) | Bridge out to Ethereum | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
-| **USDCop (Wormhole, Optimism)** | [mintscan](https://www.mintscan.io/sei/assets/factory%2Fsei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l%2F3VKKYtbQ9iq8f9CaZfgR6Cr3TUj6ypXPAn6kco6wjcAu) | Bridge out to Optimism | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
-| **USDTbs (Wormhole, BSC Chain)** | [mintscan](https://www.mintscan.io/sei/assets/factory%2Fsei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l%2F871jbn9unTavWsAe83f2Ma9GJWSv6BKsyWYLiQ6z3Pva) | Bridge out to BSC Chain | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
-| **ATOM** | [mintscan](https://www.mintscan.io/sei/assets/ibc%2FC4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9) | Bridge out to Cosmos Hub | Skip:Go | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) [Discord](https://discord.com/invite/sei) |
-| **WBTC** | [mintscan](https://www.mintscan.io/sei/assets/factory%2Fsei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l%2F7omXa4gryZ5NiBmLep7JsTtTtANCVKXwT9vbN91aS1br) | Bridge out to origin chain | Skip:Go | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
+| **USDCet (Wormhole, Ethereum)** | [seistream](https://seistream.app/address/0xa272ee55434655970f7226c95eF0068a22994B84) | Bridge out to Ethereum | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
+| **USDCop (Wormhole, Optimism)** | [seistream](https://seistream.app/address/0xC489C59b1131D379Cbc3A42AD154bBD6f1050F7c) | Bridge out to Optimism | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
+| **USDTbs (Wormhole, BSC Chain)** | [seistream](https://seistream.app/address/0x0bf5F17f0a71cf2bC014DD875e35E4B02311b8F1) | Bridge out to BSC Chain | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
+| **ATOM** | [seistream](https://seistream.app/address/0xaF5fd7Df92B103B40b9Ed8D0d002696a5436E4D8) | Bridge out to Cosmos Hub | Skip:Go | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) [Discord](https://discord.com/invite/sei) |
+| **WBTC** | [seistream](https://seistream.app/address/0xe369ddC65Ec947FCB10262AA0E08C3fB9823001a) | Bridge out to origin chain | Skip:Go | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
 
 <Info>
 Portal Bridge (legacy) is no longer listed as a bridge-out route for the Wormhole-bridged assets above (USDCso, WETH, USDCet, USDCop, USDTbs). If you hold any of these, contact [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) or [Discord](https://discord.com/invite/sei) for current migration options.

--- a/snippets/sstore-gas-live.jsx
+++ b/snippets/sstore-gas-live.jsx
@@ -129,7 +129,7 @@ export const SstoreGasLive = ({ network = 'mainnet' }) => {
           SstoreGasProbe
         </a>{' '}
         contract. Governance-adjustable — set by{' '}
-        <a href="https://www.mintscan.io/sei/proposals/109" target="_blank" rel="noopener noreferrer" className="underline">
+        <a href="https://seistream.app/proposals/109" target="_blank" rel="noopener noreferrer" className="underline">
           Proposal #109
         </a>
         .


### PR DESCRIPTION
## Summary

Replaces all Mintscan (`mintscan.io/sei`) links across the docs with Seistream (`seistream.app`) equivalents. Every replacement target was checked live. Rebased onto latest `main` (includes #47 — Prop 120 + Wormhole route changes).

## Changes

- **Governance proposals** — `mintscan.io/sei/proposals/{id}` → `seistream.app/proposals/{id}` for proposals **99, 109, 115, 116, and 120** across `STYLE_GUIDE.md`, `snippets/sstore-gas-live.jsx`, `cosmos-sdk/index.mdx`, `evm/differences-with-ethereum.mdx`, `evm/precompiles/cosmwasm-precompiles/{cosmwasm,example-usage}.mdx`, and `learn/{dev-interoperability,dev-token-standards,pointers,sip-03-migration}.mdx`.
- **Explorers nav** (`docs.json`) — "Mintscan" → "Seistream" (`https://seistream.app`).
- **`learn/explorers.mdx`** — removed the Mintscan entry (Seistream was already listed, so a swap would have duplicated it).
- **SIP-03 migration asset table** (`learn/sip-03-migration.mdx`) — each asset now links to its Seistream EVM pointer page (`seistream.app/address/{0x}`). Seistream has no working page for raw IBC/factory denoms (they render "page doesn't exist"), so the EVM pointer page is the correct equivalent.

## Verification

| Target | Result |
|---|---|
| Proposals 99 / 109 / 115 / 116 / 120 | ✅ Resolve, titles match |
| `seistream.app` (nav) | ✅ Live |
| USDC.n, USDT.kava, USDCso, USDCet, ATOM, WBTC pointer pages | ✅ Full ERC-20 token page |
| USDCop, USDTbs pointer pages | ⚠️ Valid contract page, token-info panel not indexed |

## Notes / exceptions

- **WETH** (Wormhole-bridged) kept on Mintscan — no ERC20 pointer exists on Seistream, so there is no equivalent page.
- **USDCop / USDTbs** point to their EVM pointer contracts, which currently render as verified contracts without a token-info panel (Seistream hasn't indexed their metadata).
- **`llms-full.txt`** left untouched: it is generated by `scripts/generate-llms.mjs` from the published site and will update on the next regeneration after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
