### PR TITLE
docs(sips): add live SIP index page sourced from sei-protocol/sips

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -78,6 +78,7 @@
             "pages": [
               "learn/general-governance",
               "learn/proposals",
+              "learn/sips",
               "learn/general-staking"
             ]
           },

--- a/learn/sips.mdx
+++ b/learn/sips.mdx
@@ -1,0 +1,121 @@
+---
+title: 'Sei Improvement Proposals'
+sidebarTitle: 'SIPs'
+description: 'Browse every Sei Improvement Proposal (SIP) with status, type, authorship, and section outlines pulled live from the sei-protocol/sips repository.'
+keywords: ['SIP', 'Sei Improvement Proposal', 'sei governance', 'protocol proposals', 'SIP process', 'SIP status', 'SIP-1', 'SIP-3', 'sei-protocol/sips']
+---
+
+import { SipIndex } from '/snippets/sip-index.jsx';
+
+A Sei Improvement Proposal (SIP) is a design document for a change to Sei. It might cover a new protocol feature, a change to how the project runs, or a convention for the wider ecosystem. Writing one is how you put an idea in front of the community, and how the reasoning behind a decision gets recorded.
+
+Every SIP lives in the [sei-protocol/sips](https://github.com/sei-protocol/sips) repository, and the list below reads from it directly. Titles, statuses, authors, and section outlines come from the source files rather than a copy that can fall behind.
+
+<Info>
+
+A SIP is not the same as an on-chain governance proposal. The SIP holds the design and the reasoning; the on-chain proposal is the vote that enacts it. One SIP can take several governance proposals to carry out, as SIP-3 did. For the on-chain process, see [Governance](/learn/general-governance) and [Proposals](/learn/proposals).
+
+</Info>
+
+## All proposals
+
+<SipIndex />
+
+## Proposal types
+
+Every SIP declares a type, and the type decides how much community consensus it needs. [SIP-1](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#sip-type) defines all three.
+
+| Type | Scope | Needs consensus |
+| --- | --- | --- |
+| [Standard](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#standard) | Changes that affect most implementations of Sei, such as consensus, networking, RPC, EVM and CosmWasm behavior, and contract standards. Must also declare a category. | Yes |
+| [Process](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#process) | Changes around Sei rather than inside it, such as developer tooling, node and validator procedures, and the SIP process itself. | Yes |
+| [Informational](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#informational) | Guidelines or information for the community, with no change to the protocol or development environment. | No |
+
+### Categories
+
+A Standard SIP must also declare one of five [categories](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#sip-category).
+
+| Category | Covers |
+| --- | --- |
+| Core | Consensus, execution, storage, and account signatures |
+| Networking | Mempool and network protocols |
+| Interface | RPC specifications and lower-level naming conventions |
+| Framework | EVM and CosmWasm contracts and primitives included in the Sei codebase |
+| Application | New EVM or CosmWasm standards and primitives that sit outside the Sei codebase |
+
+## Status lifecycle
+
+A successful SIP usually moves through Draft, Review, Last Call, Final, Implemented, and Activated. Each card above shows the status recorded in that proposal's own source file.
+
+| Status | What it means |
+| --- | --- |
+| [Idea](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#idea) | Written, but not yet admitted to the process and not yet numbered. |
+| [Draft](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#draft) | An editor has accepted the formatting and assigned a number. The author now gathers community feedback. |
+| [Review](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#review) | The author has worked through early feedback. Assigned reviewers now give a formal review, and it takes at least three of them. |
+| [Fast Track](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#fast-track) | For proposals that already reached consensus outside the SIP process. Runs the same way as Review. |
+| [Last Call](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#last-call) | A final window for objections, usually at least one week. |
+| [Final](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#final) | Accepted, and the specification is now frozen. |
+| [Implemented](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#implemented) | Development is complete, but the feature is not yet live on mainnet. |
+| [Activated](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#activated) | Live on Sei mainnet. |
+| [Stagnant](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#stagnant) | Inactive for four weeks while in Draft, Review, or Last Call. |
+| [Withdrawn](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#withdrawn) | The author has withdrawn the proposal. |
+| [Living](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#living) | A continuously updated proposal that never reaches Final, such as SIP-1 itself. |
+
+<Note>
+
+Once a SIP reaches Final, nobody can withdraw or edit it. To change an accepted specification, submit a new SIP that extends or replaces the original.
+
+</Note>
+
+## Guides for specific proposals
+
+SIP-3 and SIP-4 both affect how you use and build on Sei. These pages cover what they mean in practice.
+
+<CardGroup cols={2}>
+  <Card title="SIP-3 migration guide" icon="arrow-right-arrow-left" href="/learn/sip-03-migration">
+    Move assets off Cosmos-native addresses and IBC tokens before Sei becomes EVM-only.
+  </Card>
+  <Card title="SIP-3 for exchanges" icon="building-columns" href="/learn/sip-03-exchange-migration">
+    Integration changes for exchanges and custodians supporting Sei deposits and withdrawals.
+  </Card>
+  <Card title="Gas and transaction fees" icon="gas-pump" href="/learn/dev-gas">
+    How Sei's EIP-1559 implementation works, including the parameters SIP-4 revises.
+  </Card>
+  <Card title="Cosmos-SDK deprecation" icon="triangle-exclamation" href="/cosmos-sdk">
+    Legacy Cosmos SDK and CosmWasm documentation, deprecated under SIP-3.
+  </Card>
+</CardGroup>
+
+## Submit a proposal
+
+Anyone can author a SIP. Talk the idea over with the community before you write it, so you can gauge whether the proposal is needed at all.
+
+<Steps>
+
+<Step title="Read SIP-1">
+[SIP-1](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md) defines the process, the header fields your file needs, and what authors and editors are each responsible for.
+</Step>
+
+<Step title="Raise the idea with the community">
+Open a thread in [GitHub Discussions](https://github.com/sei-protocol/sips/discussions) to collect early feedback, especially from the people who would implement the change.
+</Step>
+
+<Step title="Fork the repository and add your file">
+Fork [sei-protocol/sips](https://github.com/sei-protocol/sips) and create your proposal at `sips/sip-temporary_title.md`. Put any images in `assets/sip-temporary_title/`.
+</Step>
+
+<Step title="Match the required format">
+Start the file with the two-column header table and follow the section structure described in [SIP format](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#sip-format). Keep the title under 64 characters and don't end it with a period.
+</Step>
+
+<Step title="Open a pull request">
+Submit the pull request from your fork. A [SIP editor](https://github.com/sei-protocol/sips/blob/main/sips/sip-1.md#sip-editor) reviews the formatting, assigns a number, moves the status to Draft, and opens the official comments thread.
+</Step>
+
+</Steps>
+
+<Tip>
+
+From Draft onward, keeping the proposal moving is your job. An editor will help you find the right people to talk to, but won't chase the process for you.
+
+</Tip>

--- a/snippets/sip-index.jsx
+++ b/snippets/sip-index.jsx
@@ -1,0 +1,330 @@
+export const SipIndex = () => {
+	const REPO = 'sei-protocol/sips';
+	const BRANCH = 'main';
+	const LIST_URL = `https://api.github.com/repos/${REPO}/contents/sips?ref=${BRANCH}`;
+	const CACHE_KEY = 'sei-sip-index';
+	const CACHE_TTL = 3600000;
+
+	const rawUrl = (file) => `https://raw.githubusercontent.com/${REPO}/${BRANCH}/sips/${file}`;
+	const blobUrl = (file) => `https://github.com/${REPO}/blob/${BRANCH}/sips/${file}`;
+
+	// --- Header-field parsing -------------------------------------------------
+	// Each SIP opens with a two-column markdown table. Field names drifted
+	// between SIPs ("SIP-Number" vs "SIP Number", "Comments" vs "Comments-URI",
+	// "Author" vs "Authors"), so keys are normalized to bare alphanumerics.
+	const normKey = (key) => key.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+	const pick = (meta, ...keys) => {
+		for (const key of keys) {
+			const value = meta[normKey(key)];
+			if (value) return value;
+		}
+		return '';
+	};
+
+	// Turn a table cell into plain text: `<br>` becomes a separator, markdown
+	// links collapse to their label, and contact emails are dropped so the
+	// Author row reads as names rather than mailto noise.
+	const toPlainText = (value) =>
+		value
+			.replace(/<br\s*\/?>/gi, ', ')
+			.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+			.replace(/\\([[\]])/g, '$1')
+			.replace(/\[[^\]]*@[^\]]*\]/g, '')
+			.replace(/`/g, '')
+			.replace(/\s+/g, ' ')
+			.replace(/\s+,/g, ',')
+			.replace(/[,\s]+$/, '')
+			.trim();
+
+	const firstUrl = (value) => {
+		const match = value.match(/https?:\/\/[^\s)|]+/);
+		return match ? match[0] : '';
+	};
+
+	// GitHub builds heading anchors by lowercasing the rendered text, dropping
+	// punctuation and mapping whitespace to hyphens. Mirroring that lets the
+	// outline deep-link straight into the source file.
+	const slugify = (text) =>
+		text
+			.toLowerCase()
+			.replace(/[^\w\s-]/g, '')
+			.trim()
+			.replace(/\s/g, '-');
+
+	const parseSip = (file, raw) => {
+		const number = Number((file.match(/sip-(\d+)\.md$/i) || [])[1]);
+		// Null-prototype maps: field names and heading slugs come from the SIP
+		// text, so a heading like "Constructor" must not collide with
+		// Object.prototype members.
+		const meta = Object.create(null);
+
+		// Several SIPs contain further tables in their body (editor registers,
+		// parameter lists). Only the block above the first section heading is
+		// the proposal header, so metadata parsing stops there.
+		const header = raw.split(/^##\s/m)[0];
+
+		for (const line of header.split('\n')) {
+			const row = line.match(/^\s*\|([^|]+)\|(.*)\|\s*$/);
+			if (!row) continue;
+			const key = row[1].trim();
+			const value = row[2].replace(/\|\s*$/, '').trim();
+			// Skip the table's alignment row (| ----- | :---- |).
+			if (/^:?-{2,}:?$/.test(key)) continue;
+			if (!key || meta[normKey(key)]) continue;
+			meta[normKey(key)] = value;
+		}
+
+		const headline = (header.match(/^\s*\*\*SIP[-\s]?\d+:\s*(.+?)\*\*/m) || [])[1];
+		const title = toPlainText(headline || pick(meta, 'Title') || file);
+
+		const seen = Object.create(null);
+		const sections = [];
+		const headingPattern = /^(#{2,4})\s+(.+?)\s*$/gm;
+		let match;
+		while ((match = headingPattern.exec(raw)) !== null) {
+			const text = match[2].replace(/\*\*/g, '').replace(/`/g, '').trim();
+			if (!text) continue;
+			let anchor = slugify(text);
+			// GitHub disambiguates repeated headings with a numeric suffix.
+			if (seen[anchor] !== undefined) {
+				seen[anchor] += 1;
+				anchor = `${anchor}-${seen[anchor]}`;
+			} else {
+				seen[anchor] = 0;
+			}
+			sections.push({ level: match[1].length, text, anchor });
+		}
+
+		const type = toPlainText(pick(meta, 'Type'));
+		const category = toPlainText(pick(meta, 'Category'));
+
+		return {
+			number,
+			file,
+			title,
+			description: toPlainText(pick(meta, 'Description')),
+			// SIP-3/4/5 fold the category into Type as "Standard (Core)"; SIP-2
+			// keeps it in its own row. Present both the same way.
+			type: type && category && !type.includes(category) ? `${type} (${category})` : type || category,
+			status: toPlainText(pick(meta, 'Status')) || 'Unknown',
+			author: toPlainText(pick(meta, 'Author', 'Authors')),
+			reviewer: toPlainText(pick(meta, 'Reviewer', 'Editor')),
+			created: toPlainText(pick(meta, 'Created')),
+			discussion: firstUrl(pick(meta, 'Comments', 'Comments-URI', 'CommentsURI')),
+			sections
+		};
+	};
+
+	// --- Data loading ---------------------------------------------------------
+	const [sips, setSips] = useState([]);
+	const [state, setState] = useState('loading');
+
+	useEffect(() => {
+		let cancelled = false;
+
+		const readCache = () => {
+			try {
+				const cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+				if (cached && Date.now() - cached.time < CACHE_TTL && Array.isArray(cached.sips)) {
+					return cached.sips;
+				}
+			} catch {
+				// Corrupt or unavailable storage just means we fetch again.
+			}
+			return null;
+		};
+
+		// Primary path: one directory listing, then the files it names.
+		const loadFromApi = async () => {
+			const res = await fetch(LIST_URL, { headers: { Accept: 'application/vnd.github+json' } });
+			if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+			const files = (await res.json()).filter((entry) => entry.type === 'file' && /^sip-\d+\.md$/i.test(entry.name)).map((entry) => entry.name);
+			if (!files.length) throw new Error('No SIP files listed');
+			return Promise.all(
+				files.map(async (file) => {
+					const fileRes = await fetch(rawUrl(file));
+					if (!fileRes.ok) throw new Error(`${file}: ${fileRes.status}`);
+					return parseSip(file, await fileRes.text());
+				})
+			);
+		};
+
+		// Fallback for when the unauthenticated API quota is exhausted: walk
+		// sip-1.md upwards off the raw CDN and stop after a run of misses.
+		const loadByProbing = async () => {
+			const found = [];
+			let misses = 0;
+			for (let n = 1; n <= 40 && misses < 3; n++) {
+				const file = `sip-${n}.md`;
+				try {
+					const res = await fetch(rawUrl(file));
+					if (res.ok) {
+						found.push(parseSip(file, await res.text()));
+						misses = 0;
+					} else {
+						misses += 1;
+					}
+				} catch {
+					misses += 1;
+				}
+			}
+			if (!found.length) throw new Error('No SIPs reachable');
+			return found;
+		};
+
+		const cached = readCache();
+		if (cached) {
+			setSips(cached);
+			setState('ready');
+			return;
+		}
+
+		loadFromApi()
+			.catch(loadByProbing)
+			.then((parsed) => {
+				if (cancelled) return;
+				const ordered = parsed.sort((a, b) => a.number - b.number);
+				setSips(ordered);
+				setState('ready');
+				try {
+					localStorage.setItem(CACHE_KEY, JSON.stringify({ time: Date.now(), sips: ordered }));
+				} catch {
+					// Cache is an optimization; ignore quota or privacy-mode errors.
+				}
+			})
+			.catch(() => {
+				if (cancelled) return;
+				setState('error');
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	// --- Presentation ---------------------------------------------------------
+	// Colors follow the SIP-1 lifecycle: in-progress states are neutral/amber,
+	// accepted and shipped states are green, ended states are muted or red.
+	const statusStyles = {
+		idea: 'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300',
+		draft: 'bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-300',
+		review: 'bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-300',
+		'fast track': 'bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-300',
+		'last call': 'bg-purple-100 text-purple-800 dark:bg-purple-500/15 dark:text-purple-300',
+		final: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300',
+		implemented: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300',
+		activated: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300',
+		living: 'bg-teal-100 text-teal-800 dark:bg-teal-500/15 dark:text-teal-300',
+		stagnant: 'bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400',
+		withdrawn: 'bg-red-100 text-red-800 dark:bg-red-500/15 dark:text-red-300'
+	};
+
+	const statusClass = (status) => statusStyles[status.toLowerCase()] || statusStyles.idea;
+
+	const cardClass = 'rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900/40 p-5';
+	const linkClass =
+		'inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium no-underline transition-colors ' +
+		'bg-white text-neutral-800 border border-neutral-200 hover:bg-neutral-100 ' +
+		'dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-700';
+
+	const ExternalLinkIcon = () => (
+		<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+			<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+			<path d="M15 3h6v6" />
+			<path d="M10 14 21 3" />
+		</svg>
+	);
+
+	const Field = ({ label, value }) =>
+		value ? (
+			<div>
+				<div className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-500">{label}</div>
+				<div className="text-sm text-neutral-800 dark:text-neutral-200">{value}</div>
+			</div>
+		) : null;
+
+	if (state === 'loading') {
+		return (
+			<div className={`${cardClass} not-prose text-sm text-neutral-600 dark:text-neutral-400`}>
+				Loading proposals from{' '}
+				<code style={{ fontFamily: 'var(--sei-font-mono)' }}>
+					{REPO}
+				</code>
+				…
+			</div>
+		);
+	}
+
+	if (state === 'error') {
+		return (
+			<div className={`${cardClass} not-prose text-sm text-neutral-600 dark:text-neutral-400`}>
+				Could not reach the SIPs repository. Browse the proposals directly at{' '}
+				<a href={`https://github.com/${REPO}/tree/${BRANCH}/sips`} target="_blank" rel="noopener noreferrer">
+					github.com/{REPO}
+				</a>
+				.
+			</div>
+		);
+	}
+
+	return (
+		<div className="not-prose flex flex-col gap-4">
+			{sips.map((sip) => (
+				<div key={sip.number} className={cardClass}>
+					<div className="flex flex-wrap items-center gap-2">
+						<span className="rounded-md px-2 py-0.5 text-sm font-semibold text-white" style={{ backgroundColor: 'var(--sei-maroon-100, #600014)', fontFamily: 'var(--sei-font-mono)' }}>
+							SIP-{sip.number}
+						</span>
+						<span className={`rounded-md px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${statusClass(sip.status)}`}>{sip.status}</span>
+						{sip.type ? <span className="text-xs text-neutral-500 dark:text-neutral-400">{sip.type}</span> : null}
+					</div>
+
+					<h3 className="mt-3 mb-1 text-lg font-semibold text-neutral-900 dark:text-neutral-100">{sip.title}</h3>
+
+					{sip.description ? <p className="mt-0 mb-4 text-sm text-neutral-600 dark:text-neutral-400">{sip.description}</p> : null}
+
+					<div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+						<Field label="Author" value={sip.author} />
+						<Field label="Reviewer" value={sip.reviewer} />
+						<Field label="Created" value={sip.created} />
+					</div>
+
+					{sip.sections.length ? (
+						<details className="mt-4 border-t border-neutral-200 pt-3 dark:border-neutral-800">
+							<summary className="cursor-pointer text-sm font-medium text-neutral-700 dark:text-neutral-300">Contents ({sip.sections.length} sections)</summary>
+							<ul className="mt-3 mb-0 list-none space-y-1 pl-0">
+								{sip.sections.map((section) => (
+									<li key={section.anchor} style={{ paddingLeft: `${(section.level - 2) * 16}px` }}>
+										<a href={`${blobUrl(sip.file)}#${section.anchor}`} target="_blank" rel="noopener noreferrer" className="text-sm text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100">
+											{section.text}
+										</a>
+									</li>
+								))}
+							</ul>
+						</details>
+					) : null}
+
+					<div className="mt-4 flex flex-wrap gap-2">
+						<a href={blobUrl(sip.file)} target="_blank" rel="noopener noreferrer" className={linkClass}>
+							Read SIP-{sip.number} <ExternalLinkIcon />
+						</a>
+						{sip.discussion ? (
+							<a href={sip.discussion} target="_blank" rel="noopener noreferrer" className={linkClass}>
+								Discussion <ExternalLinkIcon />
+							</a>
+						) : null}
+					</div>
+				</div>
+			))}
+
+			<p className="mt-0 text-xs text-neutral-500 dark:text-neutral-500">
+				Pulled live from{' '}
+				<a href={`https://github.com/${REPO}/tree/${BRANCH}/sips`} target="_blank" rel="noopener noreferrer">
+					{REPO}
+				</a>
+				. Statuses and metadata reflect the {BRANCH} branch.
+			</p>
+		</div>
+	);
+};

--- a/snippets/sip-index.jsx
+++ b/snippets/sip-index.jsx
@@ -2,8 +2,12 @@ export const SipIndex = () => {
 	const REPO = 'sei-protocol/sips';
 	const BRANCH = 'main';
 	const LIST_URL = `https://api.github.com/repos/${REPO}/contents/sips?ref=${BRANCH}`;
-	const CACHE_KEY = 'sei-sip-index';
+	// Suffix is bumped whenever parseSip's output shape changes, so a cached
+	// entry from an older build is discarded instead of rendered.
+	const CACHE_KEY = 'sei-sip-index-v1';
 	const CACHE_TTL = 3600000;
+	// Highest sip-N.md the fallback path will look for.
+	const MAX_PROBE = 40;
 
 	const rawUrl = (file) => `https://raw.githubusercontent.com/${REPO}/${BRANCH}/sips/${file}`;
 	const blobUrl = (file) => `https://github.com/${REPO}/blob/${BRANCH}/sips/${file}`;
@@ -44,13 +48,25 @@ export const SipIndex = () => {
 
 	// GitHub builds heading anchors by lowercasing the rendered text, dropping
 	// punctuation and mapping whitespace to hyphens. Mirroring that lets the
-	// outline deep-link straight into the source file.
+	// outline deep-link straight into the source file. Letters and digits are
+	// matched by Unicode property so accented headings keep their characters,
+	// and underscores survive because GitHub keeps them in snake_case names.
 	const slugify = (text) =>
 		text
 			.toLowerCase()
-			.replace(/[^\w\s-]/g, '')
+			.replace(/[^\p{L}\p{N}_\s-]/gu, '')
 			.trim()
 			.replace(/\s/g, '-');
+
+	// Reduce a heading to the text GitHub would render, since the anchor is
+	// derived from that rather than from the markdown source.
+	const headingText = (markdown) =>
+		markdown
+			.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+			.replace(/\*\*/g, '')
+			.replace(/\*/g, '')
+			.replace(/`/g, '')
+			.trim();
 
 	const parseSip = (file, raw) => {
 		const number = Number((file.match(/sip-(\d+)\.md$/i) || [])[1]);
@@ -65,10 +81,15 @@ export const SipIndex = () => {
 		const header = raw.split(/^##\s/m)[0];
 
 		for (const line of header.split('\n')) {
-			const row = line.match(/^\s*\|([^|]+)\|(.*)\|\s*$/);
-			if (!row) continue;
-			const key = row[1].trim();
-			const value = row[2].replace(/\|\s*$/, '').trim();
+			const trimmed = line.trim();
+			if (!trimmed.startsWith('|')) continue;
+			// The closing pipe is optional in GitHub-flavored markdown, so drop
+			// it only when present rather than requiring it.
+			const cells = trimmed.slice(1).split('|');
+			if (cells.length && cells[cells.length - 1].trim() === '') cells.pop();
+			if (cells.length < 2) continue;
+			const key = cells[0].trim();
+			const value = cells.slice(1).join('|').trim();
 			// Skip the table's alignment row (| ----- | :---- |).
 			if (/^:?-{2,}:?$/.test(key)) continue;
 			if (!key || meta[normKey(key)]) continue;
@@ -80,10 +101,14 @@ export const SipIndex = () => {
 
 		const seen = Object.create(null);
 		const sections = [];
+		// Fenced blocks can contain lines that look like headings (SIP-1's format
+		// section quotes a template), and those produce anchors GitHub never
+		// renders, so strip the fences before scanning.
+		const prose = raw.replace(/^```[\s\S]*?^```/gm, '');
 		const headingPattern = /^(#{2,4})\s+(.+?)\s*$/gm;
 		let match;
-		while ((match = headingPattern.exec(raw)) !== null) {
-			const text = match[2].replace(/\*\*/g, '').replace(/`/g, '').trim();
+		while ((match = headingPattern.exec(prose)) !== null) {
+			const text = headingText(match[2]);
 			if (!text) continue;
 			let anchor = slugify(text);
 			// GitHub disambiguates repeated headings with a numeric suffix.
@@ -135,40 +160,40 @@ export const SipIndex = () => {
 			return null;
 		};
 
+		// Fetch and parse one file, returning null instead of throwing so a
+		// single failure never takes down the whole listing.
+		const readSip = async (file) => {
+			try {
+				const res = await fetch(rawUrl(file));
+				if (!res.ok) return null;
+				return parseSip(file, await res.text());
+			} catch {
+				return null;
+			}
+		};
+
 		// Primary path: one directory listing, then the files it names.
 		const loadFromApi = async () => {
 			const res = await fetch(LIST_URL, { headers: { Accept: 'application/vnd.github+json' } });
 			if (!res.ok) throw new Error(`GitHub API ${res.status}`);
 			const files = (await res.json()).filter((entry) => entry.type === 'file' && /^sip-\d+\.md$/i.test(entry.name)).map((entry) => entry.name);
 			if (!files.length) throw new Error('No SIP files listed');
-			return Promise.all(
-				files.map(async (file) => {
-					const fileRes = await fetch(rawUrl(file));
-					if (!fileRes.ok) throw new Error(`${file}: ${fileRes.status}`);
-					return parseSip(file, await fileRes.text());
-				})
-			);
+			// One unreadable file should cost that single card, not send the whole
+			// listing down the fallback path and refetch everything.
+			const fetched = await Promise.all(files.map(readSip));
+			const parsed = fetched.filter(Boolean);
+			if (!parsed.length) throw new Error('No SIP files could be read');
+			return parsed;
 		};
 
-		// Fallback for when the unauthenticated API quota is exhausted: walk
-		// sip-1.md upwards off the raw CDN and stop after a run of misses.
+		// Fallback for when the unauthenticated API quota is exhausted: probe
+		// sip-1.md through sip-40.md on the raw CDN. Every number is requested
+		// so a withdrawn or reserved number cannot truncate the index the way
+		// stopping after a run of misses would.
 		const loadByProbing = async () => {
-			const found = [];
-			let misses = 0;
-			for (let n = 1; n <= 40 && misses < 3; n++) {
-				const file = `sip-${n}.md`;
-				try {
-					const res = await fetch(rawUrl(file));
-					if (res.ok) {
-						found.push(parseSip(file, await res.text()));
-						misses = 0;
-					} else {
-						misses += 1;
-					}
-				} catch {
-					misses += 1;
-				}
-			}
+			const numbers = Array.from({ length: MAX_PROBE }, (_, i) => i + 1);
+			const fetched = await Promise.all(numbers.map((n) => readSip(`sip-${n}.md`)));
+			const found = fetched.filter(Boolean);
 			if (!found.length) throw new Error('No SIPs reachable');
 			return found;
 		};
@@ -203,30 +228,127 @@ export const SipIndex = () => {
 		};
 	}, []);
 
-	// --- Presentation ---------------------------------------------------------
-	// Colors follow the SIP-1 lifecycle: in-progress states are neutral/amber,
-	// accepted and shipped states are green, ended states are muted or red.
-	const statusStyles = {
-		idea: 'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300',
-		draft: 'bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-300',
-		review: 'bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-300',
-		'fast track': 'bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-300',
-		'last call': 'bg-purple-100 text-purple-800 dark:bg-purple-500/15 dark:text-purple-300',
-		final: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300',
-		implemented: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300',
-		activated: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300',
-		living: 'bg-teal-100 text-teal-800 dark:bg-teal-500/15 dark:text-teal-300',
-		stagnant: 'bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400',
-		withdrawn: 'bg-red-100 text-red-800 dark:bg-red-500/15 dark:text-red-300'
+	// --- Theming --------------------------------------------------------------
+	// Mintlify serves a prebuilt stylesheet, so Tailwind utilities that appear
+	// only inside a snippet aren't guaranteed to exist in it. Variants carrying
+	// an opacity modifier (`dark:bg-neutral-900/40`) drop out that way, which is
+	// what left these cards white on a black page. The other data snippets here
+	// watch the `dark` class on <html> and style inline from the style.css
+	// tokens instead, so this follows the same approach.
+	const [isDark, setIsDark] = useState(false);
+
+	useEffect(() => {
+		const root = document.documentElement;
+		const sync = () => setIsDark(root.classList.contains('dark'));
+		sync();
+		const observer = new MutationObserver(sync);
+		observer.observe(root, { attributes: true, attributeFilter: ['class'] });
+		return () => observer.disconnect();
+	}, []);
+
+	const byMode = (light, dark) => (isDark ? dark : light);
+
+	const theme = {
+		cardBg: byMode('var(--sei-card-bg-light)', 'var(--sei-card-bg-dark)'),
+		border: byMode('var(--sei-card-border-light)', 'var(--sei-card-border-dark)'),
+		strong: byMode('var(--sei-grey-600)', 'var(--sei-white)'),
+		body: byMode('var(--sei-grey-300)', 'var(--sei-grey-50)'),
+		muted: byMode('var(--sei-grey-200)', 'var(--sei-grey-75)'),
+		label: byMode('var(--sei-gold-100)', 'var(--sei-gold-25)'),
+		accent: byMode('var(--sei-maroon-100)', 'var(--sei-maroon-25)'),
+		hoverBg: byMode('rgba(96, 0, 20, 0.02)', 'rgba(96, 0, 20, 0.08)'),
+		hoverBorder: byMode('rgba(96, 0, 20, 0.35)', 'rgba(185, 155, 161, 0.25)')
 	};
 
-	const statusClass = (status) => statusStyles[status.toLowerCase()] || statusStyles.idea;
+	// Tones map the SIP-1 lifecycle onto the Sei palette: gold while a proposal
+	// is still moving, green once accepted or shipped, grey for dormant states,
+	// red for withdrawn. These mirror the style.css tokens as literal hex
+	// because each badge tints its own fill, and the alpha channels can't be
+	// derived from a var() reference. `--sei-live` and `--sei-error` are pitched
+	// for dark surfaces and drop under 2:1 as text on white, so light mode takes
+	// a darkened counterpart.
+	const TONES = {
+		live: byMode('#1a7a00', '#38df00'),
+		error: byMode('#c20a00', '#fa0c00'),
+		gold: byMode('#966f22', '#d6c9ac'),
+		maroon: byMode('#600014', '#b99ba1'),
+		grey: byMode('#666666', '#999999')
+	};
 
-	const cardClass = 'rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900/40 p-5';
-	const linkClass =
-		'inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium no-underline transition-colors ' +
-		'bg-white text-neutral-800 border border-neutral-200 hover:bg-neutral-100 ' +
-		'dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-700';
+	const STATUS_TONES = {
+		idea: 'grey',
+		draft: 'gold',
+		review: 'gold',
+		'fast track': 'gold',
+		'last call': 'gold',
+		final: 'live',
+		implemented: 'live',
+		activated: 'live',
+		living: 'maroon',
+		stagnant: 'grey',
+		withdrawn: 'error'
+	};
+
+	const channels = (hex) => {
+		const n = parseInt(hex.slice(1), 16);
+		return `${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}`;
+	};
+
+	const eyebrow = {
+		fontFamily: 'var(--sei-font-mono)',
+		fontSize: '10px',
+		letterSpacing: '0.04em',
+		textTransform: 'uppercase'
+	};
+
+	const statusStyle = (status) => {
+		const hex = TONES[STATUS_TONES[status.toLowerCase()] || 'grey'];
+		const rgb = channels(hex);
+		return {
+			...eyebrow,
+			color: hex,
+			backgroundColor: `rgba(${rgb}, ${byMode(0.09, 0.14)})`,
+			border: `1px solid rgba(${rgb}, ${byMode(0.28, 0.32)})`,
+			borderRadius: 'var(--sei-radius-sm)',
+			padding: '3px 6px',
+			whiteSpace: 'nowrap'
+		};
+	};
+
+	const cardStyle = {
+		background: theme.cardBg,
+		border: `1px solid ${theme.border}`,
+		borderRadius: 'var(--sei-radius-sm)',
+		padding: '20px'
+	};
+
+	const buttonStyle = {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '6px',
+		padding: '6px 12px',
+		fontFamily: 'var(--sei-font-mono)',
+		fontSize: '12px',
+		letterSpacing: '0.02em',
+		color: theme.strong,
+		background: 'transparent',
+		border: `1px solid ${theme.border}`,
+		borderRadius: 'var(--sei-radius-sm)',
+		textDecoration: 'none',
+		transition: 'background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease'
+	};
+
+	// Inline styles can't express :hover, so the maroon card hover from
+	// style.css is reproduced with handlers.
+	const hoverSwap = (hovering) => (event) => {
+		event.currentTarget.style.backgroundColor = hovering ? theme.hoverBg : 'transparent';
+		event.currentTarget.style.borderColor = hovering ? theme.hoverBorder : theme.border;
+		event.currentTarget.style.color = hovering ? theme.accent : theme.strong;
+	};
+
+	const tintSwap = (hovering) => (event) => {
+		event.currentTarget.style.color = hovering ? theme.accent : theme.body;
+	};
 
 	const ExternalLinkIcon = () => (
 		<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -239,28 +361,31 @@ export const SipIndex = () => {
 	const Field = ({ label, value }) =>
 		value ? (
 			<div>
-				<div className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-500">{label}</div>
-				<div className="text-sm text-neutral-800 dark:text-neutral-200">{value}</div>
+				<div style={{ ...eyebrow, color: theme.label, marginBottom: '3px' }}>{label}</div>
+				<div style={{ fontSize: '14px', color: theme.body }}>{value}</div>
 			</div>
 		) : null;
 
+	const statusMessage = { ...cardStyle, fontSize: '14px', color: theme.body };
+
 	if (state === 'loading') {
 		return (
-			<div className={`${cardClass} not-prose text-sm text-neutral-600 dark:text-neutral-400`}>
-				Loading proposals from{' '}
-				<code style={{ fontFamily: 'var(--sei-font-mono)' }}>
-					{REPO}
-				</code>
-				…
+			<div className="not-prose" style={statusMessage}>
+				Loading proposals from <code style={{ fontFamily: 'var(--sei-font-mono)' }}>{REPO}</code>…
 			</div>
 		);
 	}
 
 	if (state === 'error') {
 		return (
-			<div className={`${cardClass} not-prose text-sm text-neutral-600 dark:text-neutral-400`}>
+			<div className="not-prose" style={statusMessage}>
 				Could not reach the SIPs repository. Browse the proposals directly at{' '}
-				<a href={`https://github.com/${REPO}/tree/${BRANCH}/sips`} target="_blank" rel="noopener noreferrer">
+				<a
+					href={`https://github.com/${REPO}/tree/${BRANCH}/sips`}
+					target="_blank"
+					rel="noopener noreferrer"
+					style={{ color: theme.accent }}
+				>
 					github.com/{REPO}
 				</a>
 				.
@@ -269,34 +394,75 @@ export const SipIndex = () => {
 	}
 
 	return (
-		<div className="not-prose flex flex-col gap-4">
+		<div className="not-prose" style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
 			{sips.map((sip) => (
-				<div key={sip.number} className={cardClass}>
-					<div className="flex flex-wrap items-center gap-2">
-						<span className="rounded-md px-2 py-0.5 text-sm font-semibold text-white" style={{ backgroundColor: 'var(--sei-maroon-100, #600014)', fontFamily: 'var(--sei-font-mono)' }}>
+				<div key={sip.number} style={cardStyle}>
+					<div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '8px' }}>
+						<span
+							style={{
+								...eyebrow,
+								fontSize: '11px',
+								color: 'var(--sei-white)',
+								backgroundColor: 'var(--sei-maroon-100)',
+								borderRadius: 'var(--sei-radius-sm)',
+								padding: '3px 7px'
+							}}
+						>
 							SIP-{sip.number}
 						</span>
-						<span className={`rounded-md px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${statusClass(sip.status)}`}>{sip.status}</span>
-						{sip.type ? <span className="text-xs text-neutral-500 dark:text-neutral-400">{sip.type}</span> : null}
+						<span style={statusStyle(sip.status)}>{sip.status}</span>
+						{sip.type ? <span style={{ fontSize: '12px', color: theme.muted }}>{sip.type}</span> : null}
 					</div>
 
-					<h3 className="mt-3 mb-1 text-lg font-semibold text-neutral-900 dark:text-neutral-100">{sip.title}</h3>
+					<h3
+						style={{
+							fontFamily: 'var(--sei-font-display)',
+							fontSize: '18px',
+							fontWeight: 600,
+							letterSpacing: '-0.01em',
+							color: theme.strong,
+							margin: '14px 0 0'
+						}}
+					>
+						{sip.title}
+					</h3>
 
-					{sip.description ? <p className="mt-0 mb-4 text-sm text-neutral-600 dark:text-neutral-400">{sip.description}</p> : null}
+					{sip.description ? (
+						<p style={{ fontSize: '14px', lineHeight: 1.6, color: theme.body, margin: '6px 0 0' }}>{sip.description}</p>
+					) : null}
 
-					<div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+					<div
+						style={{
+							display: 'grid',
+							gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+							gap: '12px',
+							marginTop: '16px'
+						}}
+					>
 						<Field label="Author" value={sip.author} />
 						<Field label="Reviewer" value={sip.reviewer} />
 						<Field label="Created" value={sip.created} />
 					</div>
 
+					{/* style.css frames every <details> as the shared accordion with
+					    !important, so the outline is inset by the summary's own 16px
+					    padding rather than given a competing border here. */}
 					{sip.sections.length ? (
-						<details className="mt-4 border-t border-neutral-200 pt-3 dark:border-neutral-800">
-							<summary className="cursor-pointer text-sm font-medium text-neutral-700 dark:text-neutral-300">Contents ({sip.sections.length} sections)</summary>
-							<ul className="mt-3 mb-0 list-none space-y-1 pl-0">
+						<details style={{ marginTop: '16px' }}>
+							<summary style={{ fontSize: '13px', color: theme.body }}>
+								Contents ({sip.sections.length} sections)
+							</summary>
+							<ul style={{ listStyle: 'none', margin: 0, padding: '0 16px 12px' }}>
 								{sip.sections.map((section) => (
-									<li key={section.anchor} style={{ paddingLeft: `${(section.level - 2) * 16}px` }}>
-										<a href={`${blobUrl(sip.file)}#${section.anchor}`} target="_blank" rel="noopener noreferrer" className="text-sm text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100">
+									<li key={section.anchor} style={{ paddingLeft: `${(section.level - 2) * 16}px`, margin: '4px 0' }}>
+										<a
+											href={`${blobUrl(sip.file)}#${section.anchor}`}
+											target="_blank"
+											rel="noopener noreferrer"
+											style={{ fontSize: '13px', color: theme.body, textDecoration: 'none', transition: 'color 0.15s ease' }}
+											onMouseEnter={tintSwap(true)}
+											onMouseLeave={tintSwap(false)}
+										>
 											{section.text}
 										</a>
 									</li>
@@ -305,12 +471,26 @@ export const SipIndex = () => {
 						</details>
 					) : null}
 
-					<div className="mt-4 flex flex-wrap gap-2">
-						<a href={blobUrl(sip.file)} target="_blank" rel="noopener noreferrer" className={linkClass}>
+					<div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', marginTop: '16px' }}>
+						<a
+							href={blobUrl(sip.file)}
+							target="_blank"
+							rel="noopener noreferrer"
+							style={buttonStyle}
+							onMouseEnter={hoverSwap(true)}
+							onMouseLeave={hoverSwap(false)}
+						>
 							Read SIP-{sip.number} <ExternalLinkIcon />
 						</a>
 						{sip.discussion ? (
-							<a href={sip.discussion} target="_blank" rel="noopener noreferrer" className={linkClass}>
+							<a
+								href={sip.discussion}
+								target="_blank"
+								rel="noopener noreferrer"
+								style={buttonStyle}
+								onMouseEnter={hoverSwap(true)}
+								onMouseLeave={hoverSwap(false)}
+							>
 								Discussion <ExternalLinkIcon />
 							</a>
 						) : null}
@@ -318,9 +498,14 @@ export const SipIndex = () => {
 				</div>
 			))}
 
-			<p className="mt-0 text-xs text-neutral-500 dark:text-neutral-500">
+			<p style={{ fontSize: '12px', color: theme.muted, margin: 0 }}>
 				Pulled live from{' '}
-				<a href={`https://github.com/${REPO}/tree/${BRANCH}/sips`} target="_blank" rel="noopener noreferrer">
+				<a
+					href={`https://github.com/${REPO}/tree/${BRANCH}/sips`}
+					target="_blank"
+					rel="noopener noreferrer"
+					style={{ color: theme.accent }}
+				>
 					{REPO}
 				</a>
 				. Statuses and metadata reflect the {BRANCH} branch.


### PR DESCRIPTION
## Summary

The docs link out to individual SIPs from five pages but never listed them, so
readers had to browse [sei-protocol/sips](https://github.com/sei-protocol/sips)
to find out what exists or what state a proposal is in. This adds a page under
**Learn > Governance** that indexes every proposal.

The list is built from the repository at page load rather than copied into the
docs, so status, type, authorship and section outlines cannot drift from the
source.

## What's included

- `snippets/sip-index.jsx`: reads the `sips/` directory, parses each proposal's
  header table and heading structure, and renders a card per SIP with a status
  badge, metadata, a collapsible section outline, and links to the source file
  and discussion thread.
- `learn/sips.mdx`: the page. Around the live list it covers the three proposal
  types, five categories and eleven lifecycle statuses, with every row linking
  into the relevant SIP-1 section instead of restating it. Also cross-links
  SIP-3 and SIP-4 to the existing migration and gas pages.
- `docs.json`: one nav entry.

## Notes for review

**Anchors were verified, not assumed.** The outline deep-links depend on
reproducing GitHub's heading-anchor rules. I rendered all five SIPs through
GitHub's markdown API and diffed its anchors against the generated ones: 121 of
121 match, including `Background & Motivation`, which becomes
`background--motivation`, and `Context/Background`, which becomes
`contextbackground`.

**Header parsing handles real inconsistencies between the files.** SIP-5 uses
`SIP Number` where others use `SIP-Number`. SIP-2 uses `Comments-URI`, lists two
authors under `Authors` split by `<br>`, and keeps `Category` in its own row
while SIP-3, SIP-4 and SIP-5 fold it into `Type`. Authorship is escaped-bracket
emails in SIP-1 and `mailto:` links elsewhere. Parsing stops at the first section
heading so the editor register in SIP-1 and the parameter tables in SIP-5 cannot
leak into the metadata.

**Rate limiting.** The GitHub contents API allows 60 requests per hour per
visitor IP. If it refuses, the snippet falls back to walking `sip-1.md` upward
off the raw CDN, and the parsed index is cached in `localStorage` for an hour.
If both paths fail it degrades to a link to the repo rather than an empty page.

**No template link.** The SIPs README tells authors to copy the SIP template,
but no template file exists in that repository, so the submit steps point at
SIP-1's format section instead.

## Test plan

- [x] `docs.json` parses; all 136 referenced pages resolve
- [x] Every internal link resolves to a real page; every external URL returns 200
- [x] All 121 outline anchors diffed against GitHub's rendered output
- [x] Parsing checked against all five current SIPs
- [x] Frontmatter passes the SEO audit thresholds (title 25 chars, description 146)
- [x] Vale rules reviewed by hand (headings, terminology, qualifiers, link text)
- [x] Internal link validation covered by CI: Mintlify link-rot passed on this PR.
      It could not run locally because Mintlify rejects Node 25+, this machine
      has 26.5.1, and `.nvmrc` pins 22.
