### PR TITLE
docs: add OpenChainBench SEI RPC benchmark reference

### DIFF
--- a/learn/rpc-providers.mdx
+++ b/learn/rpc-providers.mdx
@@ -12,3 +12,5 @@ blockchain, archive nodes, and more. Some notable providers
 include:
 
 <EcosystemAppGrid category="rpc-provider" />
+
+For an independent latency and reliability comparison of public SEI RPC endpoints, see the [OpenChainBench SEI RPC benchmark](https://openchainbench.com/benchmarks/sei-rpc). It covers a set of community providers, with latency (p50/p90/p99) and success rate probed every 60 seconds from three regions and published under CC BY 4.0 alongside the open-source harness.


### PR DESCRIPTION
Adds a short benchmark reference after the RPC providers grid, linking to the [OpenChainBench SEI RPC benchmark](https://openchainbench.com/benchmarks/sei-rpc) — an independent open-source suite that probes community RPC providers every 60 seconds from three regions (US East, EU West, Singapore), publishing p50/p90/p99 latency and success rate under CC BY 4.0.