### PR TITLE
docs: document Prop 121 disabling outbound IBC, remove dead bridge-out routes and IBC remnants

### DIFF
--- a/cosmos-sdk/index.mdx
+++ b/cosmos-sdk/index.mdx
@@ -14,6 +14,6 @@ Cosmos SDK and CosmWasm functionality is being deprecated in favor of EVM-only. 
 
 In addition, [Proposal 115](https://seistream.app/proposals/115) disables CosmWasm code uploads (`MsgStoreCode`) and contract instantiations (`MsgInstantiateContract`) chain-wide. No new CosmWasm contracts can be deployed; only `execute` and `query` against pre-existing contracts remain available via the [CosmWasm precompile](/evm/precompiles/cosmwasm-precompiles/cosmwasm).
 
-[Proposal 116](https://seistream.app/proposals/116) additionally disables inbound IBC transfers. After this passes and is activated, IBC assets bridged from Cosmos chains can no longer arrive on Sei. [Proposal 120](https://seistream.app/proposals/120) re-disables inbound IBC (setting the `ibc` module's `InboundEnabled` parameter to `false`) while leaving outbound IBC unchanged. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for affected assets and migration routes.
+**IBC is now disabled in both directions.** [Proposal 116](https://seistream.app/proposals/116) and [Proposal 120](https://seistream.app/proposals/120) set the `ibc` module's `InboundEnabled` parameter to `false`, and [Proposal 121](https://seistream.app/proposals/121) set `OutboundEnabled` to `false` on July 31, 2026. No asset can be bridged into or out of Sei over IBC, and IBC assets already on Sei can no longer be redeemed on their origin chain. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for the full explanation and the list of affected assets.
 
 </Danger>

--- a/docs.json
+++ b/docs.json
@@ -663,7 +663,7 @@
     },
     {
       "source": "/evm/precompiles/cosmwasm-precompiles/ibc",
-      "destination": "/learn/sip-03-migration",
+      "destination": "/learn/sip-03-migration#ibc-is-disabled",
       "permanent": true
     },
     {
@@ -1673,7 +1673,7 @@
     "library": "fontawesome"
   },
   "banner": {
-    "content": "**Action required: IBC assets on Sei will become inaccessible**    If you hold [USDC.n](https://seiscan.io/address/0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) (USDC via Noble), [USDT.kava](https://seiscan.io/address/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) (Kava USDT), Wormhole-bridged tokens, or any other IBC asset on Sei, you **must** swap, migrate, or bridge out **before the governance proposal to disable inbound/outbound IBC transfers passes and is activated** to avoid permanent loss of access. After this, Sei will no longer support IBC bridging of assets from Cosmos-based chains to and from Sei Network.    Consult the [SIP-03 Migration Guide](/learn/sip-03-migration) for the full list of affected assets, required actions, and supported routes.    For USDC.n specifically, see: [Holders of USDC.n Need to Swap or Migrate](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/).",
+    "content": "**IBC is disabled on Sei in both directions**    [Proposal #121](https://seistream.app/proposals/121) passed on July 31, 2026 and disabled outbound IBC transfers. Inbound IBC was already disabled by [Proposal #116](https://seistream.app/proposals/116) and [Proposal #120](https://seistream.app/proposals/120). No asset can be bridged into or out of Sei over IBC.    If you hold [USDC.n](https://seiscan.io/address/0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) (USDC via Noble), [USDT.kava](https://seiscan.io/address/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) (Kava USDT), ATOM, WBTC, or any other IBC asset on Sei, it can no longer be redeemed on its origin chain. The balance still exists on Sei and can still be transferred within Sei.    See the [SIP-03 Migration Guide](/learn/sip-03-migration) for what changed, the full list of affected assets, and what remains possible.",
     "dismissible": true
   }
 }

--- a/evm/differences-with-ethereum.mdx
+++ b/evm/differences-with-ethereum.mdx
@@ -39,7 +39,7 @@ Cosmos SDK and CosmWasm functionality is being deprecated in favor of EVM-only. 
 
 [Proposal 115](https://seistream.app/proposals/115) further disables CosmWasm code uploads and contract instantiations chain-wide — no new CosmWasm contracts can be deployed. Only `execute` and `query` against pre-existing CosmWasm contracts remain available.
 
-[Proposal 116](https://seistream.app/proposals/116) additionally disables inbound IBC transfers — IBC assets bridged from Cosmos chains can no longer arrive on Sei after this passes and is activated. [Proposal 120](https://seistream.app/proposals/120) re-disables inbound IBC (setting the `ibc` module's `InboundEnabled` parameter to `false`) while leaving outbound IBC unchanged. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for affected assets and migration routes.
+**IBC is now disabled in both directions.** [Proposal 116](https://seistream.app/proposals/116) and [Proposal 120](https://seistream.app/proposals/120) set the `ibc` module's `InboundEnabled` parameter to `false`, and [Proposal 121](https://seistream.app/proposals/121) set `OutboundEnabled` to `false` on July 31, 2026. No asset can be bridged into or out of Sei over IBC, and IBC assets already on Sei can no longer be redeemed on their origin chain. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for the full explanation and the list of affected assets.
 
 </Danger>
 

--- a/evm/precompiles/cosmwasm-precompiles/bank.mdx
+++ b/evm/precompiles/cosmwasm-precompiles/bank.mdx
@@ -16,7 +16,7 @@ The bank precompile at address `0x0000000000000000000000000000000000001001` expo
 
 - **Direct Integration:** EVM contracts and dApps can call banking functions like any other smart contract method.
 - **Native Execution:** Operations are executed at the Cosmos SDK level for maximum efficiency and security.
-- **Cross-Chain Assets:** Manage both native SEI tokens and IBC assets seamlessly from EVM contracts.
+- **Any native denom:** Manage native SEI, factory tokens, and existing IBC denoms from EVM contracts. IBC is disabled on Sei (see [SIP-03](/learn/sip-03-migration#ibc-is-disabled)), so no new IBC denoms can arrive, but balances already held remain readable and transferable.
 
 **When to use `send` vs `sendNative`:** `send` moves an arbitrary `denom` (any IBC or factory token) between two EVM addresses (`0x...`) by reading the balance directly from the bank module — no `msg.value` is attached. It is gated to the registered ERC20 native pointer for that denom, so it is typically invoked from the auto-deployed pointer contract rather than from arbitrary user code. `sendNative` is for sending native SEI (the attached `msg.value`) from the EVM caller to a Cosmos bech32 (`sei1...`) destination, which is useful for crossing the EVM→Cosmos boundary when the recipient has no associated EVM address (for example, paying a Cosmos-only contract or account).
 

--- a/evm/precompiles/cosmwasm-precompiles/cosmwasm.mdx
+++ b/evm/precompiles/cosmwasm-precompiles/cosmwasm.mdx
@@ -11,7 +11,7 @@ keywords: ['cosmwasm precompile', 'ethers.js', 'wasm execution', 'cross-chain co
 
   Per [governance Proposal 115](https://seistream.app/proposals/115), CosmWasm code uploads (`MsgStoreCode`) and contract instantiations (`MsgInstantiateContract`) are disabled chain-wide. The `instantiate()` function on this precompile **will revert** for all callers. Only `execute()`, `execute_batch()`, and `query()` against pre-existing CosmWasm contracts remain functional, and all CosmWasm functionality is deprecated in favor of EVM-only per [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md).
 
-  In addition, [Proposal 116](https://seistream.app/proposals/116) disables inbound IBC transfers — IBC assets bridged from Cosmos chains can no longer arrive on Sei after this passes and is activated. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for affected assets and migration routes.
+  In addition, IBC is disabled in both directions: Proposals [116](https://seistream.app/proposals/116) and [120](https://seistream.app/proposals/120) disabled inbound IBC, and [Proposal 121](https://seistream.app/proposals/121) disabled outbound IBC on July 31, 2026. No asset can be bridged into or out of Sei over IBC. See the [SIP-03 Migration Guide](/learn/sip-03-migration) for the full explanation and the list of affected assets.
 
   For new smart contract development, use the EVM directly. See [Deploy a Smart Contract](/evm/evm-general).
 </Danger>

--- a/evm/precompiles/cosmwasm-precompiles/example-usage.mdx
+++ b/evm/precompiles/cosmwasm-precompiles/example-usage.mdx
@@ -6,7 +6,7 @@ keywords: ["precompile example", "ethers.js", "cosmwasm query", "evm integration
 
 
 <Info>
-Per [Proposal 115](https://seistream.app/proposals/115), no new CosmWasm contracts can be deployed on Sei. The examples below apply to **pre-existing CosmWasm contracts** only — `instantiate()` will revert. Separately, [Proposal 116](https://seistream.app/proposals/116) disables inbound IBC transfers as part of the [SIP-03](/learn/sip-03-migration) migration.
+Per [Proposal 115](https://seistream.app/proposals/115), no new CosmWasm contracts can be deployed on Sei. The examples below apply to **pre-existing CosmWasm contracts** only — `instantiate()` will revert. Separately, IBC is disabled in both directions as part of the [SIP-03](/learn/sip-03-migration) migration — Proposals [116](https://seistream.app/proposals/116) and [120](https://seistream.app/proposals/120) disabled inbound IBC, and [Proposal 121](https://seistream.app/proposals/121) disabled outbound IBC.
 </Info>
 
 The Sei precompiles can be used like any standard smart contract on the EVM. For

--- a/index.mdx
+++ b/index.mdx
@@ -9,13 +9,13 @@ import { NetworkTabs } from '/snippets/network-tabs.jsx';
 The first parallelized EVM blockchain delivering unmatched scalability and speed.
 
 <Danger>
-  **Action required: IBC assets on Sei will become inaccessible**
+  **IBC is disabled on Sei in both directions**
 
-  If you hold [USDC.n](https://seiscan.io/address/0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) (USDC via Noble), [USDT.kava](https://seiscan.io/address/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) (Kava USDT), Wormhole-bridged tokens, or any other IBC asset on Sei, you **must** swap, migrate, or bridge out **before the governance proposal to disable inbound/outbound IBC transfers passes and is activated** to avoid permanent loss of access. After this, Sei will no longer support IBC bridging of assets from Cosmos-based chains to and from Sei Network.
+  [Proposal #121](https://seistream.app/proposals/121) passed on July 31, 2026 and disabled outbound IBC transfers. Inbound IBC was already disabled by [Proposal #116](https://seistream.app/proposals/116) and [Proposal #120](https://seistream.app/proposals/120). No asset can be bridged into or out of Sei over IBC.
 
-  Consult the [SIP-03 Migration Guide](/learn/sip-03-migration) for the full list of affected assets, required actions, and supported routes.
+  If you hold [USDC.n](https://seiscan.io/address/0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) (USDC via Noble), [USDT.kava](https://seiscan.io/address/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) (Kava USDT), ATOM, WBTC, or any other IBC asset on Sei, it can no longer be redeemed on its origin chain. The balance still exists on Sei and can still be transferred within Sei.
 
-  For USDC.n specifically, see: [Holders of USDC.n Need to Swap or Migrate](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/).
+  See the [SIP-03 Migration Guide](/learn/sip-03-migration) for what changed, the full list of affected assets, and what remains possible.
 </Danger>
 
 ## Quick Start

--- a/learn/dev-interoperability.mdx
+++ b/learn/dev-interoperability.mdx
@@ -6,7 +6,7 @@ keywords: ['blockchain interoperability', 'EVM Cosmos bridge', 'dual address sys
 ---
 
 <Info>
-  **CosmWasm deployments are frozen, and inbound IBC is being disabled.** Per [Proposal 115](https://seistream.app/proposals/115), no new CosmWasm contracts can be uploaded or instantiated on Sei. [Proposal 116](https://seistream.app/proposals/116) additionally disables inbound IBC transfers, so IBC assets bridged from Cosmos chains can no longer arrive on Sei. The interoperability features described on this page apply to **already-deployed** CosmWasm contracts, native Bank Module assets, and Cosmos-SDK modules accessed via precompiles. For new smart contract development, build directly on the EVM. See [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md) for the full migration context.
+  **CosmWasm deployments are frozen, and IBC is disabled in both directions.** Per [Proposal 115](https://seistream.app/proposals/115), no new CosmWasm contracts can be uploaded or instantiated on Sei. Proposals [116](https://seistream.app/proposals/116), [120](https://seistream.app/proposals/120), and [121](https://seistream.app/proposals/121) disabled inbound and then outbound IBC transfers, so no asset can be bridged into or out of Sei over IBC. The interoperability features described on this page apply to **already-deployed** CosmWasm contracts, native Bank Module assets, and Cosmos-SDK modules accessed via precompiles. For new smart contract development, build directly on the EVM. See [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md) and the [SIP-03 Migration Guide](/learn/sip-03-migration) for the full migration context.
 </Info>
 
 ## Dual Address Support

--- a/learn/hardware-wallets.mdx
+++ b/learn/hardware-wallets.mdx
@@ -13,9 +13,9 @@ such as MetaMask.
 
 <Note>
 The legacy flow that used the Cosmos app with a Cosmos RPC endpoint is
-deprecated: per [SIP-03](/learn/sip-03-migration), Cosmos-native interfaces are
-slated for deprecation on June 15, 2026. If you still hold funds on a Ledger
-Cosmos-app (`sei1...`) account, see
+deprecated: per [SIP-03](/learn/sip-03-migration), Cosmos-native interfaces
+were slated for deprecation on June 15, 2026. If you still hold funds on a
+Ledger Cosmos-app (`sei1...`) account, see
 [Migrating a hardware or mnemonic-only wallet](/learn/sip-03-migration#migrating-a-hardware-or-mnemonic-only-wallet).
 </Note>
 

--- a/learn/sip-03-exchange-migration.mdx
+++ b/learn/sip-03-exchange-migration.mdx
@@ -6,6 +6,12 @@ keywords: ['SIP-03', 'migration', 'asset transfer', 'USDC on Sei', 'Keplr', 'Lea
 
 This section is for exchanges, custodians, and other service providers that currently support SEI token deposits and withdrawals using native (`sei1...`) addresses. It explains what SIP-03 changes, the options available for migrating customer holdings to EVM (`0x...`) addresses, and the timeline by which migration must be complete.
 
+<Warning>
+**IBC is already disabled in both directions.** Proposals [#116](https://seistream.app/proposals/116) and [#120](https://seistream.app/proposals/120) disabled inbound IBC, and [#121](https://seistream.app/proposals/121) disabled outbound IBC on July 31, 2026. No asset can be bridged into or out of Sei over IBC, so IBC is not available as a route for moving customer funds off Sei, and IBC-bridged assets held on Sei can no longer be redeemed on their origin chain. See [IBC is disabled](/learn/sip-03-migration#ibc-is-disabled).
+
+The migration options below move funds between the native and EVM sides of Sei. They are intra-chain and are not affected by the IBC parameters.
+</Warning>
+
 ### What SIP-03 changes
 
 For exchanges, the practical implication of the SIP-03 migration is that any integration treating "Sei" (native) and "Sei EVM" as two separate chains needs to be reconciled into a single integration before the Cosmos shutdown. Every native address (`sei1...`) on Sei has a corresponding EVM address (`0x...`) on the same chain. This is not two distinct chains or wallets, it is one chain with two ways to interact with it.
@@ -62,7 +68,7 @@ Key properties:
 
 ### Migration milestone
 
-Address association must be completed prior to deprecation of all Cosmos, CosmWasm and IBC related functionality, slated for **June 15, 2026**. After deprecation:
+IBC has already been disabled, in both directions, by Proposals [#116](https://seistream.app/proposals/116), [#120](https://seistream.app/proposals/120), and [#121](https://seistream.app/proposals/121). Address association must still be completed prior to deprecation of the remaining Cosmos and CosmWasm functionality, slated for **June 15, 2026**. After deprecation:
 
 - Exchanges and their users will not be able to access or transfer funds.
 - Cosmos-native transaction interfaces will no longer be available. Exchanges will not be able to broadcast Cosmos-format transactions, sign with Cosmos key derivations against the live chain, or interact with the chain through Cosmos RPC endpoints.

--- a/learn/sip-03-migration.mdx
+++ b/learn/sip-03-migration.mdx
@@ -2,17 +2,17 @@
 title: 'SIP-03 Migration Guide'
 sidebarTitle: 'SIP-03 Migration'
 description: 'Practical steps and resources for users and exchanges migrating during SIP-03, including asset transfer, USDC, and exchange migration guidance.'
-keywords: ['SIP-03', 'migration', 'asset transfer', 'USDC on Sei', 'Keplr', 'Leap', 'Compass', 'EVM wallet', 'exchange migration', 'FundsForwarder', 'address association', 'Seistream', 'Ledger', 'hardware wallet', 'mnemonic', 'private key export', 'coin type 118', 'coin type 60']
+keywords: ['SIP-03', 'migration', 'asset transfer', 'USDC on Sei', 'Keplr', 'Leap', 'Compass', 'EVM wallet', 'exchange migration', 'FundsForwarder', 'address association', 'Seistream', 'Ledger', 'hardware wallet', 'mnemonic', 'private key export', 'coin type 118', 'coin type 60', 'IBC disabled', 'InboundEnabled', 'OutboundEnabled', 'Proposal 121', 'USDC.n', 'USDT.kava']
 ---
 <Danger>
 
-**Action required: IBC assets on Sei will become inaccessible**
+**IBC is now disabled on Sei in both directions. IBC assets can no longer be bridged off Sei.**
 
-If you hold [USDC.n](https://seiscan.io/address/0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) (USDC via Noble), [USDT.kava](https://seiscan.io/address/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) (Kava USDT), Wormhole-bridged tokens, or any other IBC asset on Sei, you **must** swap, migrate, or bridge out **before [Proposal #116](https://seistream.app/proposals/116) (disables inbound IBC transfers) passes and is activated** to avoid permanent loss of access. After this, Sei will no longer support IBC bridging of assets from Cosmos-based chains to and from Sei Network.
+[Proposal #121](https://seistream.app/proposals/121) passed on July 31, 2026 and set the `ibc` module's `OutboundEnabled` parameter to `false`. Inbound IBC was already disabled by [Proposal #116](https://seistream.app/proposals/116) and [Proposal #120](https://seistream.app/proposals/120). Both directions are now closed.
 
-Consult the [IBC Asset Migration Table](#ibc-asset-migration-table) below for the full list of affected assets, required actions, and supported routes.
+If you hold [USDC.n](https://seiscan.io/address/0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) (USDC via Noble), [USDT.kava](https://seiscan.io/address/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) (Kava USDT), ATOM, WBTC, or any other IBC asset on Sei, **there is no longer a route to redeem or bridge it back to its origin chain**. The bridge-out and IBC-based migration routes that were previously available no longer function.
 
-For USDC.n specifically, see: [Holders of USDC.n Need to Swap or Migrate](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/).
+These balances still exist on Sei and can still be transferred between Sei addresses, but they can no longer be redeemed for the underlying asset. See [IBC is disabled](#ibc-is-disabled) for the current state and [Affected IBC assets](#affected-ibc-assets) for the status of each one.
 
 </Danger>
 
@@ -26,11 +26,13 @@ For the full proposal text, see:
 
 - Governance [Proposal #99](https://seistream.app/proposals/99) — initiated the migration
 
-- Governance [Proposal #115](https://seistream.app/proposals/115) — disables CosmWasm code uploads and contract instantiations. After this passes, no new CosmWasm contracts can be deployed on Sei.
+- Governance [Proposal #115](https://seistream.app/proposals/115) — disabled CosmWasm code uploads and contract instantiations. No new CosmWasm contracts can be deployed on Sei.
 
-- Governance [Proposal #116](https://seistream.app/proposals/116) — disables inbound IBC transfers. After this passes and is activated, IBC assets bridged from Cosmos chains can no longer arrive on Sei.
+- Governance [Proposal #116](https://seistream.app/proposals/116) — disabled inbound IBC transfers by setting the `ibc` module's `InboundEnabled` parameter to `false`. IBC assets bridged from Cosmos chains can no longer arrive on Sei.
 
-- Governance [Proposal #120](https://seistream.app/proposals/120) — re-disables inbound IBC transfers by setting the `ibc` module's `InboundEnabled` parameter to `false`, leaving outbound IBC unchanged. Follows up on Proposal #116.
+- Governance [Proposal #120](https://seistream.app/proposals/120) — re-set `InboundEnabled` to `false`, leaving outbound IBC unchanged at the time. Follows up on Proposal #116.
+
+- Governance [Proposal #121](https://seistream.app/proposals/121) — disabled outbound IBC transfers by setting the `ibc` module's `OutboundEnabled` parameter to `false`. IBC assets can no longer leave Sei. Passed July 31, 2026.
 
 </Info>
 
@@ -39,27 +41,69 @@ For the full proposal text, see:
 - If you use Keplr or Leap (Cosmos-style wallets) and hold assets on the native address (sei1...), you should move assets to an EVM-compatible address (0x...). Use the Asset Transfer tool linked below.
 - If you use Compass or another EVM wallet already, you’re good — continue as normal.
 
-## IBC Asset Migration Table
+## IBC is disabled
 
-If you hold any of the following IBC assets on Sei, take action before [Proposal #116](https://seistream.app/proposals/116) (disables inbound IBC transfers) passes and is activated.
+IBC (Inter-Blockchain Communication) is the Cosmos protocol that moved tokens between Sei and other Cosmos-SDK chains such as Noble, Kava, and Cosmos Hub. Assets that arrived this way exist on Sei as vouchers: an `ibc/...` denom in the bank module, backed by the real asset escrowed on the origin chain, redeemable only by sending the voucher back over the same channel it came in on.
 
-\[We’ll update this table as more resources are made available\]
+Both directions are now closed. Two parameters on Sei's `ibc` module control this, and both are `false`:
 
-| Asset | Token contract | Action(s) | Possible route(s) | Support |
-| :---- | :---- | :---- | :---- | :---- |
-| **USDC.n (USDC via Noble)** | [seiscan](https://seiscan.io/address/0x3894085ef7ff0f0aedf52e2a2704928d1ec074f1) [seistream](https://seistream.app/address/0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) | Swap to native USDC or migrate via CCTP | [Saphyre](https://saphyre.xyz/swap?inputCurrency=0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1&outputCurrency=0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392), [Symphony](https://symph.ag/), or [CCTP Exchange](https://cctp.exchange/) | [Sei blog](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/) [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei?ref=blog.sei.io) |
-| **USDT.kava (USDT via Kava)** | [seiscan](https://seiscan.io/token/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) [seistream](https://seistream.app/address/0xB75D0B03c06A926e488e2659DF1A861F860bD3d1)| Swap to a native asset via Symphony | [Symphony](https://symph.ag/) | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
-| **USDCso (Wormhole, Solana)** | [seistream](https://seistream.app/address/0x8eEDF32a4FC6fB78DDF231Cd3CcF6b7B8dF9D99d) | Bridge out to Solana | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) [Discord](https://discord.com/invite/sei) |
-| **Wormhole-bridged WETH** | [mintscan](https://www.mintscan.io/sei/assets/factory%2Fsei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l%2F4tLQqCLaoKKfNFuPjA9o39YbKUwhR1F8N29Tz3hEbfP2) | Bridge out to Ethereum | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
-| **USDCet (Wormhole, Ethereum)** | [seistream](https://seistream.app/address/0xa272ee55434655970f7226c95eF0068a22994B84) | Bridge out to Ethereum | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
-| **USDCop (Wormhole, Optimism)** | [seistream](https://seistream.app/address/0xC489C59b1131D379Cbc3A42AD154bBD6f1050F7c) | Bridge out to Optimism | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
-| **USDTbs (Wormhole, BSC Chain)** | [seistream](https://seistream.app/address/0x0bf5F17f0a71cf2bC014DD875e35E4B02311b8F1) | Bridge out to BSC Chain | Contact support | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
-| **ATOM** | [seistream](https://seistream.app/address/0xaF5fd7Df92B103B40b9Ed8D0d002696a5436E4D8) | Bridge out to Cosmos Hub | Skip:Go | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) [Discord](https://discord.com/invite/sei) |
-| **WBTC** | [seistream](https://seistream.app/address/0xe369ddC65Ec947FCB10262AA0E08C3fB9823001a) | Bridge out to origin chain | Skip:Go | [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk)  [Discord](https://discord.com/invite/sei) |
+| Parameter | Gates | Current value |
+| :---- | :---- | :---- |
+| `InboundEnabled` | IBC transfers arriving on Sei | `false` |
+| `OutboundEnabled` | IBC transfers leaving Sei | `false` |
 
-<Info>
-Portal Bridge (legacy) is no longer listed as a bridge-out route for the Wormhole-bridged assets above (USDCso, WETH, USDCet, USDCop, USDTbs). If you hold any of these, contact [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) or [Discord](https://discord.com/invite/sei) for current migration options.
-</Info>
+Each was set by a governance parameter change, which takes effect when the proposal executes. There is no separate upgrade or activation step. Inbound closed on May 12, 2026; outbound closed on July 31, 2026.
+
+| Proposal | Change | Effect |
+| :---- | :---- | :---- |
+| [#115](https://seistream.app/proposals/115) | `wasm.uploadAccess` and `wasm.instantiateAccess` → `Nobody` | No new CosmWasm contracts can be deployed |
+| [#116](https://seistream.app/proposals/116) | `ibc.InboundEnabled` → `false` | IBC assets can no longer arrive on Sei |
+| [#120](https://seistream.app/proposals/120) | `ibc.InboundEnabled` → `false` | Re-applied the inbound block |
+| [#121](https://seistream.app/proposals/121) | `ibc.OutboundEnabled` → `false` | IBC assets can no longer leave Sei |
+
+### What this means in practice
+
+**No longer possible:**
+
+- Bridging any asset onto Sei over IBC.
+- Bridging any asset off Sei over IBC, including sending a voucher back to its origin chain to redeem the underlying asset.
+- IBC-based migration routes, such as sending USDC.n back to Noble to convert it to native USDC, or routing ATOM and WBTC out through Skip:Go.
+- The **IBC precompile** at `0x0000000000000000000000000000000000001009`. Its transfer methods cannot succeed and there is no replacement. Do not build against it.
+
+**Unaffected:**
+
+- Native SEI transfers, staking, delegations, and rewards.
+- The Sei EVM, ERC-20 tokens, and native and CW pointer contracts.
+- Existing `ibc/...` balances in the bank module. They remain queryable and transferable between Sei addresses, including through their ERC-20 pointers. Only the redemption path off Sei is gone.
+- Already-deployed CosmWasm contracts, which can still be executed and queried. [Proposal #115](https://seistream.app/proposals/115) blocked only uploads and instantiations and is a separate change from the IBC parameters.
+
+<Note>
+If you have an IBC transfer that was submitted but never completed, contact [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) or [Discord](https://discord.com/invite/sei). Do not assume a pending transfer will settle or refund on its own now that both directions are closed.
+</Note>
+
+## Affected IBC assets
+
+The assets below reached Sei over a bridge that is now closed. None of them has a route back to its origin chain.
+
+| Asset | Token contract | Arrived via | Route off Sei |
+| :---- | :---- | :---- | :---- |
+| **USDC.n (USDC via Noble)** | [seiscan](https://seiscan.io/address/0x3894085ef7ff0f0aedf52e2a2704928d1ec074f1) [seistream](https://seistream.app/address/0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1) | IBC (Noble) | None (outbound IBC disabled) |
+| **USDT.kava (USDT via Kava)** | [seiscan](https://seiscan.io/token/0xb75d0b03c06a926e488e2659df1a861f860bd3d1) [seistream](https://seistream.app/address/0xB75D0B03c06A926e488e2659DF1A861F860bD3d1) | IBC (Kava) | None (outbound IBC disabled) |
+| **ATOM** | [seistream](https://seistream.app/address/0xaF5fd7Df92B103B40b9Ed8D0d002696a5436E4D8) | IBC (Cosmos Hub) | None (outbound IBC disabled) |
+| **WBTC** | [seistream](https://seistream.app/address/0xe369ddC65Ec947FCB10262AA0E08C3fB9823001a) | IBC | None (outbound IBC disabled) |
+| **USDCso (Wormhole, Solana)** | [seistream](https://seistream.app/address/0x8eEDF32a4FC6fB78DDF231Cd3CcF6b7B8dF9D99d) | Wormhole | None (Portal Bridge withdrawn) |
+| **Wormhole-bridged WETH** | [mintscan](https://www.mintscan.io/sei/assets/factory%2Fsei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l%2F4tLQqCLaoKKfNFuPjA9o39YbKUwhR1F8N29Tz3hEbfP2) | Wormhole | None (Portal Bridge withdrawn) |
+| **USDCet (Wormhole, Ethereum)** | [seistream](https://seistream.app/address/0xa272ee55434655970f7226c95eF0068a22994B84) | Wormhole | None (Portal Bridge withdrawn) |
+| **USDCop (Wormhole, Optimism)** | [seistream](https://seistream.app/address/0xC489C59b1131D379Cbc3A42AD154bBD6f1050F7c) | Wormhole | None (Portal Bridge withdrawn) |
+| **USDTbs (Wormhole, BSC Chain)** | [seistream](https://seistream.app/address/0x0bf5F17f0a71cf2bC014DD875e35E4B02311b8F1) | Wormhole | None (Portal Bridge withdrawn) |
+
+The Wormhole-bridged assets are not IBC vouchers and were not affected by Proposals #116, #120, or #121. They are listed here because Portal Bridge (legacy) is no longer available as a route off Sei.
+
+### What you can still do
+
+- **Transfer within Sei.** These balances move normally between Sei addresses and through their ERC-20 pointer contracts.
+- **Swap on a Sei DEX.** Swaps do not use IBC and still execute. These tokens can no longer be redeemed for the underlying asset, so the liquidity available for them is limited and may decline further. Check the quote before you trade.
+- **Contact support.** For anything else, including incomplete transfers and assets not listed above, reach out via [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) or [Discord](https://discord.com/invite/sei).
 
 The mention of third-party platforms does not constitute an endorsement. Users should do their own research before using any third-party service.
 
@@ -81,23 +125,21 @@ Native USDC and Circle's CCTP V2 are now supported on Sei. USDC from Noble (USDC
 - QuickStart: [USDC on Sei](/evm/usdc-on-sei)
 - Background: [USDC & CCTP v2 announcement](https://www.circle.com/blog/native-usdc-and-cctp-v2-are-coming-to-sei)
 
-#### How to swap or migrate USDC.n
+#### If you still hold USDC.n
 
-**Swap (smaller amounts):**
+<Warning>
+The route that sent USDC.n back to Noble to be reissued as native USDC required outbound IBC and **no longer works** as of [Proposal #121](https://seistream.app/proposals/121). USDC.n can no longer be redeemed through Noble or through Circle's CCTP.
+</Warning>
 
-- [DragonSwap](https://dragonswap.app/) or [Symphony](https://symph.ag/?tokenIn=0x3894085ef7ff0f0aedf52e2a2704928d1ec074f1&tokenOut=0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392) — slippage may vary depending on market conditions and liquidity.
+The only remaining option on Sei is an on-chain swap, which does not use IBC:
 
-**Migrate (larger amounts):**
-
-USDC.n reached Sei over IBC from Noble, so larger balances are best migrated to native USDC by routing back through Noble — this avoids the slippage of a direct DEX swap.
-
-- IBC-transfer your USDC.n from Sei back to Noble, where it becomes native Noble USDC, then use Circle's CCTP to mint native USDC on Sei. [CCTP Exchange](https://cctp.exchange/) is a useful frontend for the CCTP leg.
-
-Complete this **before** the SIP-03 upgrade, while IBC routing through Noble is still available.
+- [DragonSwap](https://dragonswap.app/) or [Symphony](https://symph.ag/?tokenIn=0x3894085ef7ff0f0aedf52e2a2704928d1ec074f1&tokenOut=0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392). Slippage depends on whatever liquidity remains for USDC.n.
 
 **For DeFi suppliers of USDC.n (Yei, Takara Lend, etc.):**
 
-- Wind down and withdraw your positions **before** migrating to native USDC. Failure to do so before the SIP-03 upgrade may result in inability to access your supplied assets.
+- Wind down and withdraw your positions if you have not already. Supplied USDC.n cannot be redeemed off Sei.
+
+If you are holding a balance you cannot resolve this way, contact [Sei Tech Chat](https://t.me/+KZdhZ1eE-G01NmZk) or [Discord](https://discord.com/invite/sei).
 
 ### 3) Address Association (Seistream)
 
@@ -114,7 +156,7 @@ What the tool does:
 This is a streamlined alternative to the manual association flow in [Migrating a hardware or mnemonic-only wallet](#migrating-a-hardware-or-mnemonic-only-wallet).
 
 <Warning>
-Seistream handles association for the **native SEI token only**. For USDC, USDT, ATOM, WBTC, and other IBC-bridged assets, use the [IBC Asset Migration Table](#ibc-asset-migration-table). Seistream is a third-party tool; its inclusion here is not an endorsement, and you should do your own research before connecting a wallet.
+Seistream handles association for the **native SEI token only**. It does nothing for USDC.n, USDT.kava, ATOM, WBTC, or other IBC-bridged assets. See [Affected IBC assets](#affected-ibc-assets) for their status. Seistream is a third-party tool; its inclusion here is not an endorsement, and you should do your own research before connecting a wallet.
 </Warning>
 
 ## Migrating a hardware or mnemonic-only wallet
@@ -211,6 +253,16 @@ To check whether your addresses are linked, see [Query Linked Addresses](/learn/
 **Do not confuse address linking with staking migration.** Even though `sei1...` and `0x...` addresses point to the same underlying account once associated, the chain can only recognize this link after explicit association. Without association, your staked SEI will not be accessible via EVM after the upgrade, and you will have no way to unbond or claim rewards.
 </Warning>
 
+### Can I still bridge assets into or out of Sei over IBC?
+
+No. Inbound IBC was disabled by [Proposal #116](https://seistream.app/proposals/116) and [Proposal #120](https://seistream.app/proposals/120), and outbound IBC was disabled by [Proposal #121](https://seistream.app/proposals/121) on July 31, 2026. Both the `InboundEnabled` and `OutboundEnabled` parameters on the `ibc` module are now `false`, so no IBC transfer in either direction will be accepted. See [IBC is disabled](#ibc-is-disabled).
+
+### I hold an IBC asset on Sei — is it gone?
+
+The balance is not gone. It still exists in the bank module, is still visible in explorers and wallets, and can still be transferred between Sei addresses and through its ERC-20 pointer. What is gone is the ability to send it back over IBC to redeem the underlying asset on its origin chain. See [What you can still do](#what-you-can-still-do).
+
 ### I hold USDC.n (USDC via Noble) — what should I do?
 
-You must swap or migrate your USDC.n to native USDC before the SIP-03 deprecation of Cosmos, CosmWasm and IBC related functionality, slated for **June 15, 2026**. After the upgrade, USDC.n may become inaccessible or lose its value on Sei. See the [USDC on Sei](#2-usdc-on-sei) section above for swap and migration options, or read the full announcement: [Holders of USDC.n Need to Swap or Migrate](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/).
+USDC.n can no longer be redeemed. The migration route (sending it back to Noble over IBC and reissuing native USDC through Circle's CCTP) required outbound IBC, which [Proposal #121](https://seistream.app/proposals/121) disabled on July 31, 2026.
+
+An on-chain swap to native USDC on a Sei DEX does not use IBC and still executes, subject to whatever liquidity remains. See [If you still hold USDC.n](#if-you-still-hold-usdcn) above, or read the original announcement for background: [Holders of USDC.n Need to Swap or Migrate](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/).

--- a/learn/sip-03-migration.mdx
+++ b/learn/sip-03-migration.mdx
@@ -52,7 +52,7 @@ Both directions are now closed. Two parameters on Sei's `ibc` module control thi
 | `InboundEnabled` | IBC transfers arriving on Sei | `false` |
 | `OutboundEnabled` | IBC transfers leaving Sei | `false` |
 
-Each was set by a governance parameter change, which takes effect when the proposal executes. There is no separate upgrade or activation step. Inbound closed on May 12, 2026; outbound closed on July 31, 2026.
+Each was set by a governance parameter change, which takes effect when the proposal executes. There is no separate upgrade or activation step. Inbound was closed first, by Proposals #116 and #120; outbound closed on July 31, 2026 with Proposal #121.
 
 | Proposal | Change | Effect |
 | :---- | :---- | :---- |
@@ -265,4 +265,4 @@ The balance is not gone. It still exists in the bank module, is still visible in
 
 USDC.n can no longer be redeemed. The migration route (sending it back to Noble over IBC and reissuing native USDC through Circle's CCTP) required outbound IBC, which [Proposal #121](https://seistream.app/proposals/121) disabled on July 31, 2026.
 
-An on-chain swap to native USDC on a Sei DEX does not use IBC and still executes, subject to whatever liquidity remains. See [If you still hold USDC.n](#if-you-still-hold-usdcn) above, or read the original announcement for background: [Holders of USDC.n Need to Swap or Migrate](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/).
+An on-chain swap to native USDC on a Sei DEX does not use IBC and still executes, subject to whatever liquidity remains. See [If you still hold USDC.n](#if-you-still-hold-usdc-n) above, or read the original announcement for background: [Holders of USDC.n Need to Swap or Migrate](https://blog.sei.io/announcements/holders-of-usdcn-need-to-swap-or-migrate/).

--- a/node/node-operators.mdx
+++ b/node/node-operators.mdx
@@ -1403,11 +1403,6 @@ sc-enable = true
 # Async commit queue. Larger values improve catch-up; 0 = synchronous.
 sc-async-commit-buffer = 100
 
-# How many memiavl snapshots to keep besides the latest one.
-# Defaults to 0, which keeps only the current snapshot. Raise it only if you
-# need to serve queries against an older snapshot height.
-sc-keep-recent = 0
-
 # Take a state-commit snapshot every N blocks.
 sc-snapshot-interval = 10000
 

--- a/node/node-operators.mdx
+++ b/node/node-operators.mdx
@@ -1404,9 +1404,9 @@ sc-enable = true
 sc-async-commit-buffer = 100
 
 # How many memiavl snapshots to keep besides the latest one.
-# 0 = current snapshot only. Set to 1 if you serve IBC light-client queries
-# so relayers can verify against an older snapshot height.
-sc-keep-recent = 1
+# Defaults to 0, which keeps only the current snapshot. Raise it only if you
+# need to serve queries against an older snapshot height.
+sc-keep-recent = 0
 
 # Take a state-commit snapshot every N blocks.
 sc-snapshot-interval = 10000

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -35,7 +35,7 @@ const SEI_LLMS_CONFIG = {
 		'Version compatibility: Solidity ≥ 0.8.x recommended. Sei EVM tracks the Pectra EVM (without blob transactions).',
 		'Network requirements: Mainnet chain ID 1329 (pacific-1), testnet chain ID 1328 (atlantic-2). Gas is paid in SEI (18 decimals).',
 		'Important notes: Sei has 400ms block times — set lower polling intervals than on Ethereum. Transactions touching independent state are parallelized automatically; shared-state writes are serialized.',
-		'IBC deprecation: Per SIP-03, inbound/outbound IBC transfers are being disabled. Holders of IBC assets (USDC.n, USDT.kava, Wormhole-bridged tokens) must migrate before the governance proposal activates — see /learn/sip-03-migration.'
+		'IBC disabled: Per SIP-03, IBC is disabled on Sei in both directions. Proposals 116 and 120 set the ibc module InboundEnabled parameter to false, and Proposal 121 set OutboundEnabled to false on 2026-07-31. No asset can be bridged into or out of Sei over IBC, and IBC assets already on Sei (USDC.n, USDT.kava, ATOM, WBTC) can no longer be redeemed on their origin chain. The IBC precompile at 0x0000000000000000000000000000000000001009 is non-functional. See /learn/sip-03-migration.'
 	].join('\n'),
 	quickReference: [
 		'Chain ID: mainnet 1329 (pacific-1), testnet 1328 (atlantic-2)',
@@ -140,7 +140,7 @@ const LLMS_SECTION_ORDER = [
 			"Sei is a parallelized EVM Layer 1 blockchain. Performance comes from Twin Turbo Consensus (optimistic block processing), parallel EVM execution (concurrent transactions on independent state), and SeiDB (high-throughput storage). Full Ethereum tooling compatibility — deploy standard Solidity contracts with no modifications.",
 			"Sei Giga is the next major upgrade targeting 200K TPS and 5 gigagas/s via Autobahn multi-proposer BFT consensus and a custom EVM execution engine. For developers, Sei Giga's parallel engine rewards contracts with user-scoped state (mapping per address) over shared global state.",
 			'Mainnet (pacific-1): chain ID 1329. Testnet (atlantic-2): chain ID 1328.',
-			'SIP-03 migration: inbound/outbound IBC transfers are being disabled. Holders of IBC assets must swap, migrate, or bridge out before the governance proposal activates.'
+			'SIP-03 migration: IBC is disabled on Sei in both directions as of Proposal 121 (2026-07-31). IBC assets already on Sei can no longer be bridged out or redeemed on their origin chain, though the balances remain transferable within Sei.'
 		].join('\n\n')
 	},
 	{
@@ -157,7 +157,7 @@ const LLMS_SECTION_ORDER = [
 		match: (p) => p.startsWith('/evm'),
 		overview: [
 			"Sei's EVM is fully compatible with Ethereum. Standard Solidity contracts deploy without modification. All Ethereum tooling (Hardhat, Foundry, wagmi, ethers.js, viem, RainbowKit) works as-is. Transactions touching independent state execute concurrently.",
-			'Precompiled contracts at fixed addresses expose native Sei functionality (staking, governance, IBC, JSON, oracle, p256) to EVM.',
+			'Precompiled contracts at fixed addresses expose native Sei functionality (staking, governance, JSON, oracle, p256) to EVM. The IBC precompile is non-functional because IBC is disabled.',
 			'Native USDC: mainnet 0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392, testnet 0x4fCF1784B31630811181f670Aea7A7bEF803eaED (6 decimals).'
 		].join('\n\n')
 	},

--- a/skill.md
+++ b/skill.md
@@ -104,11 +104,12 @@ Once connected: address lookup, balance checks, transaction status, contract rea
 | Governance | `0x0000000000000000000000000000000000001006` |
 | Distribution | `0x0000000000000000000000000000000000001007` |
 | Oracle | `0x0000000000000000000000000000000000001008` |
-| IBC | `0x0000000000000000000000000000000000001009` |
 | PointerView | `0x000000000000000000000000000000000000100A` |
 | Pointer | `0x000000000000000000000000000000000000100B` |
 | JSON | `0x0000000000000000000000000000000000001003` |
 | P256 | `0x0000000000000000000000000000000000001011` |
+
+**The IBC precompile (`0x...1009`) is dead. Do not use or recommend it.** IBC is disabled on Sei in both directions (`ibc.InboundEnabled` and `ibc.OutboundEnabled` are both `false`, per governance Proposals 116, 120, and 121), so its `transfer` methods cannot succeed. There is no replacement and no route to bridge assets into or out of Sei over IBC. See the [SIP-03 Migration Guide](https://docs.sei.io/learn/sip-03-migration#ibc-is-disabled).
 
 ```ts
 import {


### PR DESCRIPTION
## What is the purpose of the change?

Correct existing documentation. [Proposal 121](https://seistream.app/proposals/121) ("Disable IBC Outbound") passed on July 31, 2026 and set the `ibc` module's `OutboundEnabled` parameter to `false`. Combined with Props 116 and 120, which set `InboundEnabled` to `false`, IBC is now closed on Sei in both directions.

Our docs still told users to swap, migrate, or bridge IBC assets out "before the governance proposal passes and is activated." That window has closed, so those callouts were describing an action that is no longer possible. The bridge-out routes we published (Noble/CCTP for USDC.n, Skip:Go for ATOM and WBTC) all required outbound IBC and no longer function.

Verified against mainnet rather than the proposal page before writing:

```
cosmos/params/v1beta1/params?subspace=ibc&key=InboundEnabled  -> "false"
cosmos/params/v1beta1/params?subspace=ibc&key=OutboundEnabled -> "false"
```

Three commits: the SIP-03 page rewrite, a repo-wide sweep for remnants outside those pages, and one node-config cleanup that fell out of the sweep.

## Describe the changes to the documentation

### 1. SIP-03 pages (`6bb038d`)

**`learn/sip-03-migration.mdx`** — the substantive rewrite:

- Danger callout now states current status instead of prompting action before a vote.
- New **IBC is disabled** section: the two governing parameters and their values, the proposal history (115/116/120/121), and an explicit split of what is no longer possible vs. what is unaffected. The key point for users is that IBC balances are *not* gone — they remain in the bank module and still transfer within Sei, including through their ERC-20 pointers. Only the redemption path off Sei is closed.
- The old **IBC Asset Migration Table** became **Affected IBC assets**. Its `Action(s)` and `Possible route(s)` columns contained nothing but dead routes, so annotating them with "no longer works" would have been worse than restructuring. Columns are now `Asset | Token contract | Arrived via | Route off Sei`, and every row reads `None`.
- New **What you can still do** section: transfer within Sei, swap on a DEX, contact support.
- Removed the "migrate larger amounts via Noble → CCTP" instructions and the Skip:Go routes.
- Two new FAQ entries on IBC status, and the USDC.n answer rewritten.

**Callouts folded to include Prop 121:** `index.mdx`, the `docs.json` banner, `cosmos-sdk/index.mdx`, `evm/differences-with-ethereum.mdx`, `learn/dev-interoperability.mdx`, and both CosmWasm precompile pages.

**`learn/sip-03-exchange-migration.mdx`:** notes that IBC is unavailable as a route for moving customer funds off Sei, and that the native↔EVM migration options are intra-chain and unaffected by the IBC parameters.

**IBC precompile killed.** The page itself was deleted in an earlier pass and the precompile table on `evm/precompiles/example-usage.mdx` never listed it, so two surfaces remained: removed `0x...1009` from the `skill.md` precompile table and replaced it with an explicit do-not-use note, and added it to the *No longer possible* list. Also repointed the old page's redirect at `#ibc-is-disabled` so stale links land on the status rather than the top of a long page.

### 2. Repo-wide sweep (`5bca467`)

Swept all 17 tracked files containing "IBC". Three live remnants outside the pages above:

- **`scripts/generate-llms.mjs`** — the most important find. Its hand-curated config block still told LLM consumers that IBC transfers "are being disabled" and that holders "must migrate before the governance proposal activates", and listed IBC among the usable precompiles. This script regenerates `llms.txt` and `llms-full.txt` weekly, so the stale claim would have kept re-emitting itself after every page fix.
- **`evm/precompiles/cosmwasm-precompiles/bank.mdx`** — a "Cross-Chain Assets: manage IBC assets seamlessly" bullet implied bridging capability that no longer exists. The underlying capability is real, so this reframes rather than deletes: native SEI, factory tokens, and existing IBC denoms, with no new ones able to arrive.
- **`node/node-operators.mdx`** — `sc-keep-recent = 1` was recommended solely so relayers could verify IBC light-client queries against an older snapshot height.

Deliberately left in place:

- `snippets/changelog.jsx` (14 mentions) — historical release notes about `sei-ibc-go` upgrades and past IBC fixes. Accurate history; removing it would falsify the changelog.
- `.github/styles/Sei/Headings.yml` — `IBC` in the Vale acronym allow-list, still needed for the new "IBC is disabled" heading.
- `docs.json` — the five legacy `/ibc-*` redirects, preserved per `AGENTS.md`.
- `llms.txt` / `llms-full.txt` (62 mentions combined) — generated artifacts that `AGENTS.md` forbids hand-editing. They pull page bodies from the deployed site, so they regenerate correctly on the next `regenerate-llms.yml` run after this merges. Fixing the script above is the actual fix.

### 3. `sc-keep-recent` removed from the SeiDB tuning block (`67ef261`)

Once the IBC relayer rationale was gone, the stanza just restated the chain default that the auto-generated Default Configurations block already documents (`sc-keep-recent = 0`, `node-operators.mdx:245`). The hand-written block covers "values most node operators tune in practice", so a knob with no live reason to tune it does not belong in it. Removed from the tuning block; still documented in the generated defaults section, so nothing is lost for an operator looking it up.

**This is the only change in the PR that touches node guidance rather than prose.** If operators keep an older snapshot for archival or debugging reasons the docs never recorded, this is the line to push back on.

## Notes

**Reviewer judgment calls worth a look:**

1. **Wormhole assets are not IBC.** USDCso, WETH, USDCet, USDCop, and USDTbs arrived over Wormhole and were *not* affected by 116/120/121 — they were already routeless from the Portal Bridge (legacy) delisting. They stay in the table because holders are in the same position, but the page says so explicitly so the two causes don't get conflated.

2. **DEX swaps are kept.** A swap is an ordinary on-chain transaction and doesn't touch IBC, so Symphony/DragonSwap still execute. Rather than delete them, they're framed factually: these tokens can no longer be redeemed for the underlying, so liquidity is limited and may decline. Check the quote before trading. No trading advice per the repo's content boundaries.

3. **Prose matched to house style.** Ran a humanizer pass over the added text. The repo averages 3.34 em/en dashes per 1000 words across 131 untouched `.mdx` files; the first draft was at 11.11. Now 3.28. Dashes were kept only where the construction already exists in these files (the `- Governance [Proposal #NNN](…) — …` bullets sit beside an untouched line using the identical pattern; two pre-existing FAQ headings use the same em-dash construction).

**Verification:** `scripts/generate-llms.mjs` parses under `node --check`; `docs.json` parses; anchor links and redirect destinations validate repo-wide. The check surfaced two **pre-existing** broken anchors in files this PR doesn't touch — `#custom-abi` in `evm/querying-the-evm.mdx` and `#creating-and-deploying-an-erc20-token` in `evm/evm-hardhat.mdx`. Left alone, flagged for a separate fix.

**One follow-up this PR deliberately does not resolve:**

- **The June 15, 2026 date has passed** but still reads as a future deadline in `learn/sip-03-exchange-migration.mdx` and `learn/hardware-wallets.mdx`. I don't know the current status of the Cosmos/CosmWasm interface shutdown, and guessing would be worse than a stale date. Needs someone who knows.

**One thing left as-is on purpose:** a `mintscan` link survives on the Wormhole WETH row. It's a `factory/…` denom and no working Seistream or Seiscan equivalent could be found, so the working link stayed rather than swapping in a broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
