### PR TITLE
docs: add Vultisig to recommended wallets

### DIFF
--- a/learn/wallets.mdx
+++ b/learn/wallets.mdx
@@ -42,6 +42,7 @@ different features and levels of security.
 | Rabby | ✅ | Mnemonic / Priv/Passkey | 60 | Software | ✅ | [Rabby Wallet](https://chromewebstore.google.com/detail/rabby-wallet/acmacodkjbdgmoleebolmdjonilkdbch) |
 | OKX | ✅ | Mnemonic / Privkey | 118 / 60 | Software | ✅ | [OKX Wallet](https://web3.okx.com/wallet/sei-evm) |
 | Gem Wallet | ✅ | Mnemonic / Privkey | 118 / 60 | Software | ✅ | [Gem Wallet](https://gemwallet.com/sei-wallet/) |
+| Vultisig | ✅ | MPC / Seedless | 60 | Software | ✅ | [Vultisig](https://vultisig.com/) |
 
 Wallets with coin type 118 use the Cosmos HD derivation path; the same key still maps to a unique EVM `0x...` address via Sei's address-association system.
 


### PR DESCRIPTION
Adds Vultisig to the Recommended Wallets table in `learn/wallets.mdx`.

Vultisig is a free, open-source, self-custody multi-chain wallet (iOS, Android, desktop, Chrome extension). It connects to Sei as an EVM wallet: the extension announces via EIP-6963 (rdns `me.vultisig`), so it appears in standard EVM wallet pickers on Sei dapps.

Column notes:
- **EVM ✅ / Coin Type 60** — Vultisig derives Sei on the EVM path (coin type 60), verified from the wallet's own derivation source (its `coinType` map resolves Sei to the Ethereum coin type).
- **Auth Method "MPC / Seedless"** — no mnemonic/seed phrase exists; the key is generated as shares across the user's devices (same column style as the existing "MPC / Keyless" entry).
- **Mobile ✅** — native iOS + Android apps.

## receipts

no runtime changes

One table row in `learn/wallets.mdx`; matches existing column format exactly.