### PR TITLE
docs: restore prebuilt seid binary install option (v6.6.1 ships binaries)

### DIFF
--- a/evm/installing-seid-cli.mdx
+++ b/evm/installing-seid-cli.mdx
@@ -12,24 +12,55 @@ The `seid` CLI is the command-line tool for interacting with the Sei blockchain.
 
 ## Prerequisites
 
-- Go 1.23+: Installation instructions are available [here](https://go.dev/doc/install).
+- Go 1.23+ (build from source only): Installation instructions are available [here](https://go.dev/doc/install). The prebuilt binary has no prerequisites.
 
 ## Installation
 
-To install seid, locate the version you wish to use on the [sei-chain releases page](https://github.com/sei-protocol/sei-chain/releases). A list of the currently used versions on mainnet and testnet are displayed right below.
+To install `seid`, locate the version you wish to use on the [sei-chain releases page](https://github.com/sei-protocol/sei-chain/releases). A list of the currently used versions on mainnet and testnet are displayed right below.
 
 <VersionTable />
 
-Then, execute the following commands with the version that you picked:
+<Tabs>
+  <Tab title="Prebuilt binary (recommended)">
+    Each release attaches a statically linked `seid` build for `linux/amd64` with no
+    runtime dependencies:
 
-```bash
-git clone https://github.com/sei-protocol/sei-chain
-cd sei-chain
-git checkout [VERSION]
-make install
-```
+    ```bash
+    VERSION=<version-tag>  # e.g. v6.6.0 — see the version table above
+    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
 
-You can verify that seid was installed correctly by running:
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
+
+    # Verify integrity before trusting the binary; extract and install only if it passes
+    sha256sum -c checksums.txt --ignore-missing \
+      && tar -xzf ${FILE} seid \
+      && sudo install -m 0755 seid /usr/local/bin/seid
+    ```
+
+    <Info>
+      Prebuilt binaries are `linux/amd64` only and omit hardware Ledger support. On
+      other architectures, or if you sign with a Ledger device, build from source.
+    </Info>
+
+    <Note>
+      Previously installed with `make install`? An older copy in `$(go env GOPATH)/bin`
+      can shadow `/usr/local/bin/seid` depending on your `PATH` order — `which -a seid`
+      lists every copy.
+    </Note>
+  </Tab>
+
+  <Tab title="Build from source">
+    ```bash
+    git clone https://github.com/sei-protocol/sei-chain
+    cd sei-chain
+    git checkout <version-tag>
+    make install
+    ```
+  </Tab>
+</Tabs>
+
+You can verify that `seid` was installed correctly by running:
 
 ```bash
 seid version
@@ -37,7 +68,7 @@ seid version
 
 ## Troubleshooting Installation
 
-<Warning>If you encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.</Warning>
+<Warning>If you built from source and encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.</Warning>
 
 - Use `go env GOPATH` to find your GOPATH
 - Add the following lines to your `~/.bashrc` or `~/.zshrc`:
@@ -268,8 +299,12 @@ This will remove the specified wallet from your local keyring. Be cautious, as t
 
 ## Uninstalling seid
 
-If you need to remove `seid` from your system, you can delete the binary from your `$GOPATH/bin` directory:
+If you need to remove `seid` from your system, delete the binary from wherever it was installed:
 
 ```bash
+# Prebuilt binary install
+sudo rm /usr/local/bin/seid
+
+# Build-from-source install
 rm $(go env GOPATH)/bin/seid
 ```

--- a/evm/installing-seid-cli.mdx
+++ b/evm/installing-seid-cli.mdx
@@ -26,7 +26,7 @@ To install `seid`, locate the version you wish to use on the [sei-chain releases
     runtime dependencies:
 
     ```bash
-    VERSION=<version-tag>  # e.g. v6.6.0 — see the version table above
+    VERSION=<version-tag>  # e.g. v6.6.1 — see the version table above
     FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
 
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
@@ -39,7 +39,8 @@ To install `seid`, locate the version you wish to use on the [sei-chain releases
     ```
 
     <Info>
-      Prebuilt binaries are `linux/amd64` only and omit hardware Ledger support. On
+      Prebuilt binaries are attached from `v6.6.1` onward — for earlier versions, build
+      from source. They are `linux/amd64` only and omit hardware Ledger support. On
       other architectures, or if you sign with a Ledger device, build from source.
     </Info>
 

--- a/node/index.mdx
+++ b/node/index.mdx
@@ -63,6 +63,9 @@ timedatectl
 
 ##### Install Go
 
+Only needed if you build `seid` from source — the prebuilt binary and Docker
+install paths in the next step don't require Go.
+
 Suggested Version: Go 1.24.x (required for seid v6.3+)
 
 ###### Installation Steps
@@ -85,49 +88,89 @@ go version
 </Step>
 
 <Step title="Install Sei">
-##### Install Sei Binary
+##### Install the `seid` binary
 
-```bash
-# Clone repository and install
-git clone https://github.com/sei-protocol/sei-chain.git
-cd sei-chain
-git checkout <version-tag>  # Replace with specific version
-make install
+See the Network Versions table above for the current recommended version.
 
-# Verify installation
-seid version
-```
+<Tabs>
+  <Tab title="Prebuilt binary (recommended)">
+    Each release attaches a statically linked `seid` build for `linux/amd64` with no
+    runtime dependencies: no Go toolchain and no shared libraries to install.
 
-See Network Versions table above for current recommended version.
+    ```bash
+    VERSION=<version-tag>  # e.g. v6.6.0 — see the Network Versions table above
+    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
 
-<Accordion title="Alternative: Docker Image">
-  Official Docker images are available at GitHub Container Registry.
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
 
-  ```bash
-  # Pull the latest version
-  docker pull ghcr.io/sei-protocol/sei:latest
+    # Verify integrity before trusting the binary; extract and install only if it passes
+    sha256sum -c checksums.txt --ignore-missing \
+      && tar -xzf ${FILE} seid \
+      && sudo install -m 0755 seid /usr/local/bin/seid
 
-  # Or pull a specific version (recommended)
-  docker pull ghcr.io/sei-protocol/sei:v6.3.1
-  ```
+    # Verify installation
+    seid version
+    ```
 
-  Available architectures: linux/amd64 and linux/arm64.
-</Accordion>
+    <Info>
+      Prebuilt binaries are `linux/amd64` only, omit hardware Ledger support, and
+      don't include the optional [RocksDB state-store backend](/node/rocksdb-backend).
+      On other architectures, or if you sign with a Ledger device, build from source
+      or use Docker; a RocksDB-enabled `seid` must be built from source.
+    </Info>
 
-<Info>
-  If you encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.
+    <Note>
+      Switching from a previous `make install` build? Remove the old copy
+      (`rm -f "$(go env GOPATH)/bin/seid"`) or make sure your service unit points at
+      `/usr/local/bin/seid` — `which -a seid` lists every copy on your `PATH`.
+    </Note>
+  </Tab>
 
-  Add the following to your `~/.bashrc` or `~/.zshrc`:
+  <Tab title="Build from source">
+    Requires Go and a C toolchain (see the Environment Setup step above).
 
-  ```bash
-  export GOPATH=$(go env GOPATH)
-  export PATH=$PATH:$GOPATH/bin
-  ```
+    ```bash
+    # Clone repository and install
+    git clone https://github.com/sei-protocol/sei-chain.git
+    cd sei-chain
+    git checkout <version-tag>  # Replace with specific version
+    make install
 
-  Then reload your shell with `source ~/.bashrc` or `source ~/.zshrc`.
+    # Verify installation
+    seid version
+    ```
 
-  For more information see [here](https://pkg.go.dev/cmd/go#hdr-GOPATH_environment_variable).
-</Info>
+    <Info>
+      If you encounter an error like `command not found: seid`, you may need to set your GOPATH environment variable.
+
+      Add the following to your `~/.bashrc` or `~/.zshrc`:
+
+      ```bash
+      export GOPATH=$(go env GOPATH)
+      export PATH=$PATH:$GOPATH/bin
+      ```
+
+      Then reload your shell with `source ~/.bashrc` or `source ~/.zshrc`.
+
+      For more information see [here](https://pkg.go.dev/cmd/go#hdr-GOPATH_environment_variable).
+    </Info>
+  </Tab>
+
+  <Tab title="Docker">
+    Official Docker images are available at GitHub Container Registry.
+
+    ```bash
+    # Pull the latest version
+    docker pull ghcr.io/sei-protocol/sei:latest
+
+    # Or pull a specific version (recommended)
+    docker pull ghcr.io/sei-protocol/sei:v6.3.1
+    ```
+
+    Available architectures: linux/amd64 and linux/arm64.
+  </Tab>
+</Tabs>
 
 ##### Initialize Chain Files
 

--- a/node/index.mdx
+++ b/node/index.mdx
@@ -98,7 +98,7 @@ See the Network Versions table above for the current recommended version.
     runtime dependencies: no Go toolchain and no shared libraries to install.
 
     ```bash
-    VERSION=<version-tag>  # e.g. v6.6.0 — see the Network Versions table above
+    VERSION=<version-tag>  # e.g. v6.6.1 — see the Network Versions table above
     FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
 
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
@@ -114,10 +114,12 @@ See the Network Versions table above for the current recommended version.
     ```
 
     <Info>
-      Prebuilt binaries are `linux/amd64` only, omit hardware Ledger support, and
-      don't include the optional [RocksDB state-store backend](/node/rocksdb-backend).
-      On other architectures, or if you sign with a Ledger device, build from source
-      or use Docker; a RocksDB-enabled `seid` must be built from source.
+      Prebuilt binaries are attached from `v6.6.1` onward — for earlier versions, build
+      from source or use Docker. They are `linux/amd64` only, omit hardware Ledger
+      support, and don't include the optional
+      [RocksDB state-store backend](/node/rocksdb-backend). On other architectures, or
+      if you sign with a Ledger device, build from source or use Docker; a
+      RocksDB-enabled `seid` must be built from source.
     </Info>
 
     <Note>

--- a/node/node-operators.mdx
+++ b/node/node-operators.mdx
@@ -1563,23 +1563,55 @@ EOF
 
 ## Update Procedures
 
+<Info>
+  Upgrade with the same method you originally installed with: `make install`
+  writes `seid` to `$(go env GOPATH)/bin`, while the prebuilt-binary flow
+  installs to `/usr/local/bin`. Mixing the two leaves separate binaries on your
+  `PATH`, and your service unit may keep running the old version —
+  `which -a seid` lists every copy.
+</Info>
+
 ### Minor Updates
 
 For minor updates that are non-consensus-breaking:
 
-```bash
-# Stop node
-sudo systemctl stop seid
+<Tabs>
+  <Tab title="Prebuilt binary">
+    ```bash
+    # Stop node
+    sudo systemctl stop seid
 
-# Update binary
-cd sei-chain
-git fetch --all
-git checkout [new-version]
-make install
+    # Download and verify the new release binary
+    VERSION=<new-version>  # the new release tag, e.g. v6.6.0
+    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
 
-# Restart node
-sudo systemctl restart seid
-```
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
+    sha256sum -c checksums.txt --ignore-missing \
+      && tar -xzf ${FILE} seid \
+      && sudo install -m 0755 seid /usr/local/bin/seid
+
+    # Restart node
+    sudo systemctl restart seid
+    ```
+  </Tab>
+
+  <Tab title="Build from source">
+    ```bash
+    # Stop node
+    sudo systemctl stop seid
+
+    # Update binary
+    cd sei-chain
+    git fetch --all
+    git checkout <new-version>
+    make install
+
+    # Restart node
+    sudo systemctl restart seid
+    ```
+  </Tab>
+</Tabs>
 
 ### Major Updates
 
@@ -1591,18 +1623,38 @@ For major upgrades that introduce state-breaking changes:
 3. Update/replace the binary
 4. Restart the node.
 
-```bash
-# After node halts
-cd sei-chain
-git pull
-git checkout [new-version]
-make install
-sudo systemctl restart seid
-```
+<Tabs>
+  <Tab title="Prebuilt binary">
+    ```bash
+    # After node halts
+    VERSION=<new-version>  # the new release tag, e.g. v6.6.0
+    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz
+
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
+    curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
+    sha256sum -c checksums.txt --ignore-missing \
+      && tar -xzf ${FILE} seid \
+      && sudo install -m 0755 seid /usr/local/bin/seid
+
+    sudo systemctl restart seid
+    ```
+  </Tab>
+
+  <Tab title="Build from source">
+    ```bash
+    # After node halts
+    cd sei-chain
+    git pull
+    git checkout <new-version>
+    make install
+    sudo systemctl restart seid
+    ```
+  </Tab>
+</Tabs>
 
 <Tip>
-  Build the upgrade before the halt-height so you can quickly replace it
-  with minimal downtime.
+  Download the release archive (or build the new binary) ahead of the
+  halt-height so the swap takes seconds at upgrade time.
 </Tip>
 
 ## Performance Optimization

--- a/node/node-operators.mdx
+++ b/node/node-operators.mdx
@@ -1582,7 +1582,7 @@ For minor updates that are non-consensus-breaking:
     sudo systemctl stop seid
 
     # Download and verify the new release binary
-    VERSION=<new-version>  # the new release tag, e.g. v6.6.0
+    VERSION=<new-version>  # the new release tag, e.g. v6.6.1
     FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
 
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
@@ -1627,7 +1627,7 @@ For major upgrades that introduce state-breaking changes:
   <Tab title="Prebuilt binary">
     ```bash
     # After node halts
-    VERSION=<new-version>  # the new release tag, e.g. v6.6.0
+    VERSION=<new-version>  # the new release tag, e.g. v6.6.1
     FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz
 
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}


### PR DESCRIPTION
## What

Restores the prebuilt `seid` binary install path across the three install/upgrade surfaces, by reverting the temporary revert (#45) of #44:

- `evm/installing-seid-cli.mdx`
- `node/index.mdx`
- `node/node-operators.mdx`

## Why now

#45 was an explicitly temporary revert: the prebuilt binaries weren't attached to any published release yet, so the download and `sha256sum` commands would have 404'd for readers. **That condition is now met** — `v6.6.1` ships a statically linked `seid` for `linux/amd64` plus `checksums.txt`.

The published `v6.6.1` artifact was verified end to end before restoring these docs:

- `checksums.txt` verifies against the downloaded tarball
- binary is a static ELF and carries **zero** `version_lock_lock_exclusive` symbols, i.e. the libgcc unwinder fix from sei-protocol/sei-chain#3749 / #3802 is present
- **8/8 clean boots**, and **8/8 clean under `RAYON_NUM_THREADS=1`** — the serialized-compile case that reproduced the old crash 100% of the time
- 3-node localnet reached 459 blocks, served both the Tendermint and EVM RPC endpoints, and completed a wasm store → instantiate → execute cycle (`code=0`)

## Two corrections on top of the plain revert

1. **Version examples now use `v6.6.1`, not `v6.6.0`.** `v6.6.0` has no binary assets, so anyone copy-pasting the old example would hit a 404 — the same failure mode #45 was protecting against. Updated in all four places.
2. **Both install pages now state that prebuilt binaries start at `v6.6.1`**, so readers pinned to an earlier version know to build from source or use Docker instead.

## Nothing recent was lost

`node/node-operators.mdx` picked up three commits after the revert, so a plain revert-the-revert needed checking. Verified: all **80 still-live lines** added by those commits are present in this branch, including the whole `docs(node): sync default configs from seid v6.6.0` change. (Two lines from that commit are absent, but they were deliberately removed later by `docs: drop sc-keep-recent from the SeiDB tuning block` and are not on `main` either.)

The review follow-ups from the original PR are preserved: verify-then-install `&&` chaining so nothing installs unless `sha256sum -c` exits 0, the Ledger and RocksDB caveats, and the shadowed-`PATH` notes.

`mint broken-links` passes.
