### PR TITLE
Cover linux/arm64 in the prebuilt seid install and upgrade steps

### DIFF
--- a/evm/installing-seid-cli.mdx
+++ b/evm/installing-seid-cli.mdx
@@ -22,12 +22,17 @@ To install `seid`, locate the version you wish to use on the [sei-chain releases
 
 <Tabs>
   <Tab title="Prebuilt binary (recommended)">
-    Each release attaches a statically linked `seid` build for `linux/amd64` with no
-    runtime dependencies:
+    Each release attaches statically linked `seid` builds for `linux/amd64` and
+    `linux/arm64` with no runtime dependencies:
 
     ```bash
     VERSION=<version-tag>  # e.g. v6.6.1 — see the version table above
-    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
+    case "$(uname -m)" in
+      x86_64)        ARCH=x86_64 ;;
+      aarch64|arm64) ARCH=arm64  ;;
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+    esac
+    FILE=sei-chain_${VERSION#v}_linux_${ARCH}.tar.gz  # asset filenames omit the leading v
 
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
@@ -39,9 +44,10 @@ To install `seid`, locate the version you wish to use on the [sei-chain releases
     ```
 
     <Info>
-      Prebuilt binaries are attached from `v6.6.1` onward — for earlier versions, build
-      from source. They are `linux/amd64` only and omit hardware Ledger support. On
-      other architectures, or if you sign with a Ledger device, build from source.
+      Prebuilt binaries are attached from `v6.6.1` onward, and `linux/arm64` from
+      `<arm64-release-tag>`. For earlier versions, or other architectures, build from
+      source. They omit hardware Ledger support, so if you sign with a Ledger device,
+      build from source.
     </Info>
 
     <Note>

--- a/node/index.mdx
+++ b/node/index.mdx
@@ -118,12 +118,18 @@ See the Network Versions table above for the current recommended version.
 
 <Tabs>
   <Tab title="Prebuilt binary (recommended)">
-    Each release attaches a statically linked `seid` build for `linux/amd64` with no
-    runtime dependencies: no Go toolchain and no shared libraries to install.
+    Each release attaches statically linked `seid` builds for `linux/amd64` and
+    `linux/arm64` with no runtime dependencies: no Go toolchain and no shared
+    libraries to install.
 
     ```bash
     VERSION=<version-tag>  # e.g. v6.6.1 — see the Network Versions table above
-    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
+    case "$(uname -m)" in
+      x86_64)        ARCH=x86_64 ;;
+      aarch64|arm64) ARCH=arm64  ;;
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+    esac
+    FILE=sei-chain_${VERSION#v}_linux_${ARCH}.tar.gz  # asset filenames omit the leading v
 
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
@@ -138,10 +144,10 @@ See the Network Versions table above for the current recommended version.
     ```
 
     <Info>
-      Prebuilt binaries are attached from `v6.6.1` onward. For earlier versions,
-      build from source or use Docker. They are `linux/amd64` only and omit hardware
-      Ledger support. On other architectures, or if you sign with a Ledger device,
-      build from source or use Docker.
+      Prebuilt binaries are attached from `v6.6.1` onward, and `linux/arm64` from
+      `<arm64-release-tag>`. For earlier versions, or other architectures, build from
+      source or use Docker. They omit hardware Ledger support, so if you sign with a
+      Ledger device, build from source or use Docker.
     </Info>
 
     <Note>

--- a/node/node-operators.mdx
+++ b/node/node-operators.mdx
@@ -1648,7 +1648,12 @@ For minor updates that are non-consensus-breaking:
 
     # Download and verify the new release binary
     VERSION=<new-version>  # the new release tag, e.g. v6.6.1
-    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz  # asset filenames omit the leading v
+    case "$(uname -m)" in
+      x86_64)        ARCH=x86_64 ;;
+      aarch64|arm64) ARCH=arm64  ;;
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+    esac
+    FILE=sei-chain_${VERSION#v}_linux_${ARCH}.tar.gz  # asset filenames omit the leading v
 
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt
@@ -1693,7 +1698,12 @@ For major upgrades that introduce state-breaking changes:
     ```bash
     # After node halts
     VERSION=<new-version>  # the new release tag, e.g. v6.6.1
-    FILE=sei-chain_${VERSION#v}_linux_x86_64.tar.gz
+    case "$(uname -m)" in
+      x86_64)        ARCH=x86_64 ;;
+      aarch64|arm64) ARCH=arm64  ;;
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+    esac
+    FILE=sei-chain_${VERSION#v}_linux_${ARCH}.tar.gz
 
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/${FILE}
     curl -fLO https://github.com/sei-protocol/sei-chain/releases/download/${VERSION}/checksums.txt


### PR DESCRIPTION
**Draft on purpose. Do not merge until arm64 binaries are actually attached to a sei-chain release.** These pages were reverted once before (#44) for documenting prebuilt binaries ahead of their existence, and #55 only restored them after v6.6.1 shipped. Same rule applies here.

## What this changes

Three files, eight lines. The prebuilt binary tabs hardcode `sei-chain_${VERSION#v}_linux_x86_64.tar.gz` and state the builds are `linux/amd64` only.

| File | Hunks |
|---|---|
| `evm/installing-seid-cli.mdx` | intro sentence, download snippet, `<Info>` caveat |
| `node/index.mdx` | intro sentence, download snippet, `<Info>` caveat |
| `node/node-operators.mdx` | the Minor Updates and Major Updates snippets |

The two in `node-operators.mdx` are the easy ones to miss. Without them an arm64 operator can install from the guide and then be unable to upgrade, because both update procedures would hand them an amd64 tarball.

## The detail worth reviewing

The asset token is `arm64`, but `uname -m` on Linux reports `aarch64`. So substituting `$(uname -m)` directly appears to work (it is correct on amd64 by coincidence) and then 404s on every arm64 machine. The snippet maps explicitly instead:

```bash
case "$(uname -m)" in
  x86_64)        ARCH=x86_64 ;;
  aarch64|arm64) ARCH=arm64  ;;
  *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
esac
FILE=sei-chain_${VERSION#v}_linux_${ARCH}.tar.gz
```

An unrecognised architecture stops rather than building a filename that cannot exist. Verified the mapping produces `..._linux_x86_64.tar.gz` on `x86_64` and `..._linux_arm64.tar.gz` on both `aarch64` and `arm64`.

## Before this can merge

- [ ] arm64 binaries are attached to a published sei-chain release
- [ ] replace the `<arm64-release-tag>` placeholder in `evm/installing-seid-cli.mdx` and `node/index.mdx` with the first release that carries them
- [ ] confirm the asset name matches what goreleaser actually produced (this assumes `sei-chain_<version>_linux_arm64.tar.gz`)
- [ ] confirm the arm64 tarball is covered by `checksums.txt`, since `sha256sum -c --ignore-missing` exits 0 and prints nothing for a file that is present but unlisted

## Out of scope

`node/seictl.mdx` also names x86_64 archives, but that is the seictl binary and a separate release pipeline. `node/index.mdx` line 195 ("Available architectures: linux/amd64 and linux/arm64") describes the Docker images and stays accurate. `llms.txt` and `llms-full.txt` are generated from the deployed site, so they should be regenerated after this deploys rather than hand-edited.
