### PR TITLE
docs(solidity-resources): drop dead LearnWeb3 link

### DIFF
--- a/evm/solidity-resources.mdx
+++ b/evm/solidity-resources.mdx
@@ -29,8 +29,6 @@ This page suggests a minimal set of resources for getting started with building 
   Covers the fundamentals of blockchain, DeFi, and smart contracts.
 - **[Solidity Smart Contract Development by Cyfrin Updraft](https://updraft.cyfrin.io/courses/solidity)**  
   Offers hands-on experience to become a smart contract developer.
-- **[Ethereum Developer Degree by LearnWeb3](https://learnweb3.io)**  
-  A course designed to take you from no background in web3 to building multiple applications and understanding key protocols, frameworks, and concepts.
 
 ## Intermediate Solidity
 


### PR DESCRIPTION
Resolves every open broken-external-links report: #52, #63, #70, #73. All four point at `evm/solidity-resources.mdx` and between them name two URLs.

## What is the purpose of the change?

Delete a stale link to a service that no longer exists, and close out the tracking issues.

## Describe the changes to the documentation

**Removed the "Ethereum Developer Degree by LearnWeb3" entry** (`https://learnweb3.io`) from the Basic Solidity list. The link has failed every weekly run since 2026-08-03 (502 in #52, 503 in #70 and #73), and it is not a transient outage:

- The host answers `HTTP 503` with `x-render-routing: suspend` and a body of "This service has been suspended" — Render's response for a suspended deployment. Same result for `/`, `/degrees/`, and the degree page itself, with and without a browser user agent.
- The [LearnWeb3DAO GitHub org](https://github.com/LearnWeb3DAO) has had no pushes since August 2025 and still lists the dead domain as its homepage.
- No successor domain exists. `learnweb3.xyz` responds but is an unrelated "airdrops / make money in web3" landing page, not the education platform. `learnweb3.com` / `.dev` don't resolve.
- Wayback's last successful capture is 2026-08-10.

Sending readers to a "Service Suspended" page is worse than not listing it. The section keeps four live resources (CryptoZombies, Solidity by Example, and two Cyfrin Updraft courses). Nothing else on the page references LearnWeb3.

**Left the VS Code Marketplace link as is.** #63 flagged `marketplace.visualstudio.com/items?itemName=NomicFoundation.hardhat-solidity` with a 503 on 2026-08-17. That was a one-off: it passed the 2026-08-31 and 2026-09-07 runs, returns 200 on GET (lychee's method) today, and the page body identifies `PublisherName: NomicFoundation` / `ExtensionName: hardhat-solidity`, so it isn't a soft 404. Not adding it to the lychee exclude list either — it's being checked successfully, and excluding it would hide real rot if the extension is ever renamed or unpublished.

## Notes

Verification — lychee `0.24.2` with the repo's `lychee.toml`, same args as `external-links.yml`:

```
🔍 Total.........1034
🔗 Unique.........598
✅ Successful.....497
🔀 Redirected......75
👻 Excluded.......537
🚫 Errors...........0
```

This morning's scheduled run reported 1035 / 599 / 1 error; the one-link difference is the removed URL.

`llms-full.txt` still contains the old line, but per `AGENTS.md` it is generated, not hand-edited — the weekly `regenerate-llms.yml` job will pick this up.

Closes #52
Closes #63
Closes #70
Closes #73
